### PR TITLE
Add SQLite storage layer to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Każdy piksel można kliknąć, zobaczyć czy jest wolny czy zajęty i w przysz�
 
 - **Frontend**: React + TypeScript + Tailwind CSS  
 - **Backend**: Go (Gin framework) – API REST do obsługi pikseli  
-- **Baza danych**: na start in-memory (mapa pikseli), docelowo Redis/Mongo/Postgres  
-- **Docker**: multi-stage build → jeden image z frontendem i backendem  
-- **Nginx/Reverse Proxy**: opcjonalnie do hostingu na VPS + SSL  
+- **Baza danych**: SQLite (plik tworzony domyślnie pod `backend/data/pixels.db`, można zmienić ścieżkę zmienną `PIXEL_DB_PATH`)
+- **Docker**: multi-stage build → jeden image z frontendem i backendem
+- **Nginx/Reverse Proxy**: opcjonalnie do hostingu na VPS + SSL
+
+### 💾 Przechowywanie danych backendu
+
+- Domyślny plik bazy: `backend/data/pixels.db` (tworzony automatycznie przy starcie backendu).
+- Zmienna środowiskowa `PIXEL_DB_PATH` pozwala wskazać inną lokalizację pliku.
+- Kopię zapasową najlepiej wykonywać po zatrzymaniu serwera (lub po `COMMIT`). Można też użyć polecenia `sqlite3 pixels.db ".backup backup.db"` na bieżącej instancji.
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,7 +2,11 @@ module github.com/example/kup-piksel
 
 go 1.21
 
-require github.com/gin-gonic/gin v0.0.0
+require (
+	github.com/gin-gonic/gin v0.0.0
+	github.com/mattn/go-sqlite3 v1.14.22
+)
 
 replace github.com/gin-gonic/gin => ./internal/ginlite
 
+replace github.com/mattn/go-sqlite3 => ./internal/sqlite3

--- a/backend/internal/sqlite3/go.mod
+++ b/backend/internal/sqlite3/go.mod
@@ -1,0 +1,3 @@
+module github.com/mattn/go-sqlite3
+
+go 1.21

--- a/backend/internal/sqlite3/sqlite3.go
+++ b/backend/internal/sqlite3/sqlite3.go
@@ -1,0 +1,219 @@
+package sqlite3
+
+/*
+#cgo LDFLAGS: -lsqlite3
+#include <sqlite3.h>
+#include <stdlib.h>
+
+static const char* gosqlite_errmsg(sqlite3* db) {
+        return sqlite3_errmsg(db);
+}
+*/
+import "C"
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"unsafe"
+)
+
+func init() {
+	sql.Register("sqlite3", &Driver{})
+}
+
+type Driver struct{}
+
+type conn struct {
+	db *C.sqlite3
+}
+
+type result struct {
+	lastID       int64
+	rowsAffected int64
+}
+
+type rows struct {
+	columns []string
+	data    [][]driver.Value
+	index   int
+}
+
+type tx struct {
+	c    *conn
+	done bool
+}
+
+func (d *Driver) Open(name string) (driver.Conn, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var db *C.sqlite3
+	if rc := C.sqlite3_open(cName, &db); rc != C.SQLITE_OK {
+		err := errors.New(C.GoString(C.gosqlite_errmsg(db)))
+		if db != nil {
+			C.sqlite3_close(db)
+		}
+		return nil, err
+	}
+
+	return &conn{db: db}, nil
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("prepared statements are not supported")
+}
+
+func (c *conn) Close() error {
+	if c.db == nil {
+		return nil
+	}
+	if rc := C.sqlite3_close(c.db); rc != C.SQLITE_OK {
+		return errors.New(C.GoString(C.gosqlite_errmsg(c.db)))
+	}
+	c.db = nil
+	return nil
+}
+
+func (c *conn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if err := c.execSimple("BEGIN TRANSACTION"); err != nil {
+		return nil, err
+	}
+	return &tx{c: c}, nil
+}
+
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if len(args) > 0 {
+		return nil, errors.New("query parameters are not supported")
+	}
+	return c.exec(query)
+}
+
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if len(args) > 0 {
+		return nil, errors.New("query parameters are not supported")
+	}
+	return c.query(query)
+}
+
+func (c *conn) exec(query string) (driver.Result, error) {
+	cQuery := C.CString(query)
+	defer C.free(unsafe.Pointer(cQuery))
+
+	var errMsg *C.char
+	rc := C.sqlite3_exec(c.db, cQuery, nil, nil, &errMsg)
+	if rc != C.SQLITE_OK {
+		defer C.sqlite3_free(unsafe.Pointer(errMsg))
+		return nil, errors.New(C.GoString(errMsg))
+	}
+
+	res := result{
+		lastID:       int64(C.sqlite3_last_insert_rowid(c.db)),
+		rowsAffected: int64(C.sqlite3_changes(c.db)),
+	}
+	return res, nil
+}
+
+func (c *conn) query(query string) (driver.Rows, error) {
+	cQuery := C.CString(query)
+	defer C.free(unsafe.Pointer(cQuery))
+
+	var stmt *C.sqlite3_stmt
+	if rc := C.sqlite3_prepare_v2(c.db, cQuery, -1, &stmt, nil); rc != C.SQLITE_OK {
+		return nil, errors.New(C.GoString(C.gosqlite_errmsg(c.db)))
+	}
+	defer C.sqlite3_finalize(stmt)
+
+	columnCount := int(C.sqlite3_column_count(stmt))
+	columns := make([]string, columnCount)
+	for i := 0; i < columnCount; i++ {
+		columns[i] = C.GoString(C.sqlite3_column_name(stmt, C.int(i)))
+	}
+
+	data := make([][]driver.Value, 0)
+	for {
+		rc := C.sqlite3_step(stmt)
+		if rc == C.SQLITE_ROW {
+			row := make([]driver.Value, columnCount)
+			for i := 0; i < columnCount; i++ {
+				switch C.sqlite3_column_type(stmt, C.int(i)) {
+				case C.SQLITE_INTEGER:
+					row[i] = int64(C.sqlite3_column_int64(stmt, C.int(i)))
+				case C.SQLITE_FLOAT:
+					row[i] = float64(C.sqlite3_column_double(stmt, C.int(i)))
+				case C.SQLITE_TEXT, C.SQLITE_BLOB:
+					text := C.sqlite3_column_text(stmt, C.int(i))
+					if text != nil {
+						row[i] = C.GoString((*C.char)(unsafe.Pointer(text)))
+					} else {
+						row[i] = ""
+					}
+				case C.SQLITE_NULL:
+					row[i] = nil
+				default:
+					row[i] = nil
+				}
+			}
+			data = append(data, row)
+		} else if rc == C.SQLITE_DONE {
+			break
+		} else {
+			return nil, errors.New(C.GoString(C.gosqlite_errmsg(c.db)))
+		}
+	}
+
+	return &rows{columns: columns, data: data}, nil
+}
+
+func (c *conn) execSimple(query string) error {
+	_, err := c.exec(query)
+	return err
+}
+
+func (r result) LastInsertId() (int64, error) {
+	return r.lastID, nil
+}
+
+func (r result) RowsAffected() (int64, error) {
+	return r.rowsAffected, nil
+}
+
+func (r *rows) Columns() []string {
+	return r.columns
+}
+
+func (r *rows) Close() error {
+	r.data = nil
+	return nil
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	if r.index >= len(r.data) {
+		return io.EOF
+	}
+	copy(dest, r.data[r.index])
+	r.index++
+	return nil
+}
+
+func (t *tx) Commit() error {
+	if t.done {
+		return errors.New("transaction already completed")
+	}
+	t.done = true
+	return t.c.execSimple("COMMIT")
+}
+
+func (t *tx) Rollback() error {
+	if t.done {
+		return errors.New("transaction already completed")
+	}
+	t.done = true
+	return t.c.execSimple("ROLLBACK")
+}

--- a/backend/internal/storage/sqlite/store.go
+++ b/backend/internal/storage/sqlite/store.go
@@ -1,0 +1,207 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	GridWidth     = 1000
+	GridHeight    = 1000
+	TotalPixels   = GridWidth * GridHeight
+	busyTimeoutMs = 5000
+)
+
+type Store struct {
+	db *sql.DB
+}
+
+type Pixel struct {
+	ID        int       `json:"id"`
+	Status    string    `json:"status"`
+	Color     string    `json:"color,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+type PixelState struct {
+	Width  int     `json:"width"`
+	Height int     `json:"height"`
+	Pixels []Pixel `json:"pixels"`
+}
+
+func Open(path string) (*Store, error) {
+	if path == "" {
+		return nil, errors.New("sqlite path must not be empty")
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite database: %w", err)
+	}
+
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA busy_timeout=%d", busyTimeoutMs)); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("configure busy timeout: %w", err)
+	}
+
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *Store) EnsureSchema(ctx context.Context) (err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin ensure schema: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, execErr := tx.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS pixels (
+                id INTEGER PRIMARY KEY,
+                status TEXT,
+                color TEXT,
+                url TEXT,
+                updated_at TIMESTAMP
+        )`); execErr != nil {
+		err = fmt.Errorf("create pixels table: %w", execErr)
+		return err
+	}
+
+	if _, execErr := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_pixels_status ON pixels(status)`); execErr != nil {
+		err = fmt.Errorf("create status index: %w", execErr)
+		return err
+	}
+
+	var count int
+	if err = tx.QueryRowContext(ctx, `SELECT COUNT(1) FROM pixels`).Scan(&count); err != nil {
+		err = fmt.Errorf("count pixels: %w", err)
+		return err
+	}
+
+	if count == 0 {
+		for i := 0; i < TotalPixels; i++ {
+			if ctx.Err() != nil {
+				err = ctx.Err()
+				return err
+			}
+			query := fmt.Sprintf("INSERT OR IGNORE INTO pixels(id, status, color, url, updated_at) VALUES (%d, 'free', '', '', CURRENT_TIMESTAMP)", i)
+			if _, execErr := tx.ExecContext(ctx, query); execErr != nil {
+				err = fmt.Errorf("fill pixels: %w", execErr)
+				return err
+			}
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		err = fmt.Errorf("commit ensure schema: %w", commitErr)
+		return err
+	}
+	return nil
+}
+
+func (s *Store) GetAllPixels(ctx context.Context) (PixelState, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, status, COALESCE(color, ''), COALESCE(url, ''), updated_at FROM pixels ORDER BY id`)
+	if err != nil {
+		return PixelState{}, fmt.Errorf("query pixels: %w", err)
+	}
+	defer rows.Close()
+
+	pixels := make([]Pixel, 0, TotalPixels)
+	for rows.Next() {
+		var pixel Pixel
+		var updated sql.NullTime
+		if err := rows.Scan(&pixel.ID, &pixel.Status, &pixel.Color, &pixel.URL, &updated); err != nil {
+			return PixelState{}, fmt.Errorf("scan pixel: %w", err)
+		}
+		if updated.Valid {
+			pixel.UpdatedAt = updated.Time
+		}
+		pixels = append(pixels, pixel)
+	}
+
+	if err := rows.Err(); err != nil {
+		return PixelState{}, fmt.Errorf("iterate pixels: %w", err)
+	}
+
+	return PixelState{Width: GridWidth, Height: GridHeight, Pixels: pixels}, nil
+}
+
+func (s *Store) UpdatePixel(ctx context.Context, pixel Pixel) (updated Pixel, err error) {
+	if pixel.ID < 0 || pixel.ID >= TotalPixels {
+		return Pixel{}, fmt.Errorf("invalid pixel id: %d", pixel.ID)
+	}
+
+	updated = Pixel{ID: pixel.ID}
+	if strings.EqualFold(pixel.Status, "taken") {
+		if pixel.Color == "" || pixel.URL == "" {
+			return Pixel{}, errors.New("taken pixels require color and url")
+		}
+		updated.Status = "taken"
+		updated.Color = pixel.Color
+		updated.URL = pixel.URL
+	} else {
+		updated.Status = "free"
+	}
+
+	updated.UpdatedAt = time.Now().UTC()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Pixel{}, fmt.Errorf("begin update pixel: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	query := fmt.Sprintf(
+		"UPDATE pixels SET status = %s, color = %s, url = %s, updated_at = %s WHERE id = %d",
+		quoteLiteral(updated.Status),
+		quoteLiteral(updated.Color),
+		quoteLiteral(updated.URL),
+		quoteLiteral(updated.UpdatedAt.Format(time.RFC3339Nano)),
+		updated.ID,
+	)
+
+	res, err := tx.ExecContext(ctx, query)
+	if err != nil {
+		return Pixel{}, fmt.Errorf("update pixel: %w", err)
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return Pixel{}, fmt.Errorf("rows affected: %w", err)
+	}
+	if affected == 0 {
+		return Pixel{}, sql.ErrNoRows
+	}
+
+	if err = tx.Commit(); err != nil {
+		return Pixel{}, fmt.Errorf("commit update pixel: %w", err)
+	}
+
+	return updated, nil
+}
+
+func quoteLiteral(value string) string {
+	escaped := strings.ReplaceAll(value, "'", "''")
+	return "'" + escaped + "'"
+}


### PR DESCRIPTION
## Summary
- add a SQLite-backed storage package with schema management, pixel queries and updates
- embed a minimal SQLite3 driver and wire the backend server to use the persistent store
- document the default database location and backup guidance in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc8702914c83269cbfcda48ae7d2be