### PR TITLE
Update backend Docker build target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
     mkdir -p backend/frontend_dist; \
     cp -r frontend_dist/. backend/frontend_dist/; \
     cd backend; \
-    CGO_ENABLED=1 GOOS=linux go build -o kup-piksel ./...
+    CGO_ENABLED=1 GOOS=linux go build -o kup-piksel .
 
 FROM alpine:3.19
 WORKDIR /app


### PR DESCRIPTION
## Summary
- update the Dockerfile to build only the backend root package so that the build step produces a single binary

## Testing
- docker build -t kup-pixel-test . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9370137c832685eaba71c5aec0bd