### PR TITLE
Add registration flow to auth context and UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, useCallback, useEffect, useMemo, useState } from "rea
 import { Link, Route, Routes, useNavigate, useParams } from "react-router-dom";
 import PixelCanvas, { Pixel } from "./components/PixelCanvas";
 import LoginModal from "./components/LoginModal";
+import RegisterModal from "./components/RegisterModal";
 import { useAuth } from "./useAuth";
 
 type PixelResponse = {
@@ -65,7 +66,11 @@ function usePixels() {
   return { data, loading, error } as const;
 }
 
-function LandingPage() {
+type LandingPageProps = {
+  onOpenRegister: () => void;
+};
+
+function LandingPage({ onOpenRegister }: LandingPageProps) {
   const navigate = useNavigate();
   const { data, loading, error } = usePixels();
   const { user, ensureAuthenticated, openLoginModal, logout } = useAuth();
@@ -122,15 +127,24 @@ function LandingPage() {
               </button>
             </>
           ) : (
-            <button
-              type="button"
-              onClick={() => {
-                void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
-              }}
-              className="rounded-full bg-blue-500 px-6 py-2 font-semibold text-white shadow-lg transition hover:bg-blue-400"
-            >
-              Zaloguj się
-            </button>
+            <div className="flex flex-col items-stretch gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={onOpenRegister}
+                className="rounded-full bg-blue-500 px-6 py-2 font-semibold text-white shadow-lg transition hover:bg-blue-400"
+              >
+                Załóż konto
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
+                }}
+                className="rounded-full bg-slate-800/70 px-6 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
+              >
+                Zaloguj się
+              </button>
+            </div>
           )}
         </div>
       </header>
@@ -352,10 +366,25 @@ function BuyPixelPage() {
 }
 
 export default function App() {
+  const { openLoginModal } = useAuth();
+  const [isRegisterOpen, setIsRegisterOpen] = useState(false);
+
+  const handleOpenRegister = useCallback(() => {
+    setIsRegisterOpen(true);
+  }, []);
+
+  const handleCloseRegister = useCallback(() => {
+    setIsRegisterOpen(false);
+  }, []);
+
+  const handleOpenLoginFromRegister = useCallback(() => {
+    void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
+  }, [openLoginModal]);
+
   return (
     <>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
+        <Route path="/" element={<LandingPage onOpenRegister={handleOpenRegister} />} />
         <Route path="/buy/:pixelId" element={<BuyPixelPage />} />
         <Route
           path="*"
@@ -370,6 +399,13 @@ export default function App() {
         />
       </Routes>
       <LoginModal />
+      <RegisterModal
+        isOpen={isRegisterOpen}
+        onClose={handleCloseRegister}
+        onOpenLogin={() => {
+          handleOpenLoginFromRegister();
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/components/RegisterModal.tsx
+++ b/frontend/src/components/RegisterModal.tsx
@@ -1,0 +1,149 @@
+import { FormEvent, useCallback, useState } from "react";
+import { useAuth } from "../useAuth";
+
+type RegisterModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onOpenLogin?: () => void;
+};
+
+export default function RegisterModal({ isOpen, onClose, onOpenLogin }: RegisterModalProps) {
+  const { register } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetState = useCallback(() => {
+    setEmail("");
+    setPassword("");
+    setError(null);
+    setIsSubmitting(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    resetState();
+    onClose();
+  }, [isSubmitting, onClose, resetState]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setError(null);
+      setIsSubmitting(true);
+      try {
+        await register({ email, password });
+        resetState();
+        onClose();
+      } catch (err) {
+        console.error("register error", err);
+        const message = err instanceof Error ? err.message : "Nie udało się utworzyć konta.";
+        setError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [email, password, register, resetState, onClose]
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 backdrop-blur">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-md rounded-2xl bg-slate-900/90 p-8 shadow-2xl ring-1 ring-white/10"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-100">Załóż konto</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              Podaj adres e-mail i hasło, aby utworzyć konto i rozpocząć zabawę z tablicą pikseli.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-full bg-slate-800/80 p-2 text-slate-400 transition hover:text-slate-200"
+            aria-label="Zamknij"
+          >
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <label className="block text-sm font-medium text-slate-200">
+            Adres e-mail
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
+              autoFocus
+              autoComplete="email"
+              required
+              disabled={isSubmitting}
+            />
+          </label>
+
+          <label className="block text-sm font-medium text-slate-200">
+            Hasło
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
+              autoComplete="new-password"
+              required
+              disabled={isSubmitting}
+            />
+          </label>
+
+          {error && (
+            <p role="alert" className="text-sm text-rose-400">
+              {error}
+            </p>
+          )}
+
+          <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            {onOpenLogin && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (isSubmitting) return;
+                  resetState();
+                  onClose();
+                  onOpenLogin();
+                }}
+                className="text-left text-sm font-semibold text-blue-300 transition hover:text-blue-200"
+              >
+                Masz już konto? Zaloguj się
+              </button>
+            )}
+            <div className="flex items-center justify-end gap-3 sm:justify-end">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
+                disabled={isSubmitting}
+              >
+                Anuluj
+              </button>
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? "Tworzenie..." : "Zarejestruj się"}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend the auth context with a register helper that persists the returned session
- add a reusable registration modal with e-mail/password form and error handling
- expose the registration modal from the landing page next to the existing login entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb0a6ca248326af04fd28a708e5e1