### PR TITLE
Add email verification flow for registration

### DIFF
--- a/backend/internal/mailer/mailer.go
+++ b/backend/internal/mailer/mailer.go
@@ -1,0 +1,55 @@
+package mailer
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+)
+
+type Mailer interface {
+	SendVerificationEmail(ctx context.Context, recipientEmail, token string) error
+}
+
+type LoggerMailer struct {
+	BaseURL string
+}
+
+func NewLoggerMailer(baseURL string) *LoggerMailer {
+	trimmed := strings.TrimSpace(baseURL)
+	if trimmed == "" {
+		trimmed = "http://localhost:5173"
+	}
+	return &LoggerMailer{BaseURL: trimmed}
+}
+
+func (m *LoggerMailer) SendVerificationEmail(ctx context.Context, recipientEmail, token string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	verificationURL := m.buildVerificationURL(token)
+	log.Printf("[mailer] send verification email to %s: %s", recipientEmail, verificationURL)
+	return nil
+}
+
+func (m *LoggerMailer) buildVerificationURL(token string) string {
+	base := strings.TrimRight(m.BaseURL, "/")
+	if base == "" {
+		base = "http://localhost:5173"
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return fmt.Sprintf("%s/verify-email?token=%s", base, token)
+	}
+	q := u.Query()
+	if !strings.HasSuffix(u.Path, "/verify-email") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/verify-email"
+	}
+	q.Set("token", token)
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Link, Route, Routes, useNavigate, useParams } from "react-router-dom";
 import PixelCanvas, { Pixel } from "./components/PixelCanvas";
 import LoginModal from "./components/LoginModal";
 import { useAuth } from "./useAuth";
+import VerifyEmailPage from "./VerifyEmailPage";
 
 type PixelResponse = {
   width: number;
@@ -111,7 +112,7 @@ function LandingPage() {
           {user ? (
             <>
               <span className="rounded-full bg-slate-800/80 px-4 py-2 text-slate-200">
-                Zalogowano jako <span className="font-semibold">{user.username}</span>
+                Zalogowano jako <span className="font-semibold">{user.email}</span>
               </span>
               <button
                 type="button"
@@ -357,6 +358,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/buy/:pixelId" element={<BuyPixelPage />} />
+        <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route
           path="*"
           element={

--- a/frontend/src/VerifyEmailPage.tsx
+++ b/frontend/src/VerifyEmailPage.tsx
@@ -1,0 +1,184 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useAuth } from "./useAuth";
+
+type VerifyError = Error & {
+  tokenExpired?: boolean;
+};
+
+type VerifyStatus = "idle" | "pending" | "success";
+
+export default function VerifyEmailPage() {
+  const { refresh } = useAuth();
+  const [searchParams] = useSearchParams();
+  const queryToken = useMemo(() => searchParams.get("token") ?? "", [searchParams]);
+  const [token, setToken] = useState<string>(queryToken);
+  const [status, setStatus] = useState<VerifyStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [tokenExpired, setTokenExpired] = useState(false);
+  const [hasAutoSubmitted, setHasAutoSubmitted] = useState(false);
+
+  useEffect(() => {
+    setToken(queryToken);
+  }, [queryToken]);
+
+  const verifyToken = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed === "") {
+        setError("Podaj token otrzymany w wiadomości e-mail.");
+        setTokenExpired(false);
+        return;
+      }
+
+      setStatus("pending");
+      setError(null);
+      setInfo(null);
+      setTokenExpired(false);
+
+      try {
+        const response = await fetch("/api/verify-email", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({ token: trimmed }),
+        });
+        if (!response.ok) {
+          let message = "Nie udało się potwierdzić adresu e-mail.";
+          let expired = false;
+          try {
+            const data = (await response.json()) as Record<string, unknown>;
+            if (data && typeof data.error === "string" && data.error.trim() !== "") {
+              message = data.error;
+            }
+            if (typeof data?.token_expired === "boolean") {
+              expired = data.token_expired;
+            }
+          } catch (parseError) {
+            const fallback = await response.text().catch(() => "");
+            if (fallback.trim() !== "") {
+              message = fallback;
+            }
+          }
+          const verifyError = new Error(message) as VerifyError;
+          if (expired) {
+            verifyError.tokenExpired = true;
+          }
+          throw verifyError;
+        }
+
+        const data = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+        const message = data && typeof data.message === "string" && data.message.trim() !== ""
+          ? data.message
+          : "Adres e-mail został potwierdzony.";
+
+        setStatus("success");
+        setInfo(message);
+        setError(null);
+        setTokenExpired(false);
+        await refresh().catch((refreshError) => {
+          console.error("refresh after verification", refreshError);
+        });
+      } catch (err) {
+        console.error("verify email", err);
+        const message = err instanceof Error ? err.message : "Nie udało się potwierdzić adresu e-mail.";
+        setError(message);
+        setStatus("idle");
+        if (err && typeof err === "object" && "tokenExpired" in err) {
+          setTokenExpired(Boolean((err as VerifyError).tokenExpired));
+        }
+      }
+    },
+    [refresh]
+  );
+
+  useEffect(() => {
+    if (!hasAutoSubmitted && queryToken.trim() !== "") {
+      setHasAutoSubmitted(true);
+      void verifyToken(queryToken);
+    }
+  }, [hasAutoSubmitted, queryToken, verifyToken]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void verifyToken(token);
+    },
+    [token, verifyToken]
+  );
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-6 py-12 text-center">
+      <div className="w-full max-w-lg rounded-3xl bg-slate-900/70 p-10 shadow-2xl ring-1 ring-white/10">
+        <h1 className="text-3xl font-semibold text-blue-400">Potwierdź adres e-mail</h1>
+        <p className="mt-2 text-sm text-slate-300">
+          Wpisz token przesłany w wiadomości e-mail. Po pomyślnej weryfikacji konto zostanie aktywowane automatycznie.
+        </p>
+
+        {status !== "success" && (
+          <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+            <label className="block text-left text-sm font-medium text-slate-200">
+              Token weryfikacyjny
+              <input
+                type="text"
+                value={token}
+                onChange={(event) => setToken(event.target.value)}
+                className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 font-mono text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
+                placeholder="wklej lub wpisz token"
+                required
+                disabled={status === "pending"}
+              />
+            </label>
+
+            <button
+              type="submit"
+              className="inline-flex w-full items-center justify-center rounded-full bg-blue-500 px-6 py-3 font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={status === "pending"}
+            >
+              {status === "pending" ? "Potwierdzanie..." : "Potwierdź adres"}
+            </button>
+          </form>
+        )}
+
+        {status === "success" && (
+          <div className="mt-8 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-6 text-left text-emerald-100">
+            <h2 className="text-xl font-semibold text-emerald-300">Gotowe!</h2>
+            <p className="mt-2 text-sm">{info ?? "Adres e-mail został potwierdzony."}</p>
+            <p className="mt-4 text-xs text-emerald-200/80">
+              Możesz już zamknąć tę stronę lub wrócić do tablicy pikseli, aby zalogować się na swoje konto.
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <p role="alert" className="mt-6 text-sm text-rose-400">
+            {error}
+          </p>
+        )}
+
+        {tokenExpired && (
+          <p className="mt-3 text-sm text-amber-300">
+            Token wygasł. Zarejestruj się ponownie, aby otrzymać nowy link aktywacyjny.
+          </p>
+        )}
+
+        <div className="mt-8 space-y-2 text-sm text-slate-400">
+          <p>
+            Nie widzisz wiadomości? Sprawdź folder spam lub poczekaj kilka minut – wysyłka może chwilę potrwać.
+          </p>
+          <p>
+            Wróć na
+            {" "}
+            <Link to="/" className="text-blue-300 underline">
+              stronę główną Kup Piksel
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend the SQLite schema with an email verification column and token table plus helper methods
- add a logger-based mailer, verification endpoint, and registration/login changes that require confirmed addresses
- refresh the frontend auth flow to show verification messaging and provide a token confirmation screen

## Testing
- go test ./...
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb0a7f2188326b3714d692193d153