### PR TITLE
Switch auth flow to email

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,7 +111,7 @@ function LandingPage() {
           {user ? (
             <>
               <span className="rounded-full bg-slate-800/80 px-4 py-2 text-slate-200">
-                Zalogowano jako <span className="font-semibold">{user.username}</span>
+                Zalogowano jako <span className="font-semibold">{user.email}</span>
               </span>
               <button
                 type="button"

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -3,13 +3,13 @@ import { useAuth } from "../useAuth";
 
 export default function LoginModal() {
   const { isLoginModalOpen, closeLoginModal, login, loginPrompt } = useAuth();
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const resetState = useCallback(() => {
-    setUsername("");
+    setEmail("");
     setPassword("");
     setError(null);
     setIsSubmitting(false);
@@ -27,7 +27,7 @@ export default function LoginModal() {
       setError(null);
       setIsSubmitting(true);
       try {
-        await login({ username, password });
+        await login({ email, password });
         resetState();
       } catch (err) {
         console.error("login error", err);
@@ -37,7 +37,7 @@ export default function LoginModal() {
         setIsSubmitting(false);
       }
     },
-    [login, password, resetState, username]
+    [email, login, password, resetState]
   );
 
   if (!isLoginModalOpen) {
@@ -70,14 +70,14 @@ export default function LoginModal() {
 
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
           <label className="block text-sm font-medium text-slate-200">
-            Nazwa użytkownika
+            Adres e-mail
             <input
-              type="text"
-              value={username}
-              onChange={(event) => setUsername(event.target.value)}
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
               className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
               autoFocus
-              autoComplete="username"
+              autoComplete="email"
               required
               disabled={isSubmitting}
             />

--- a/frontend/src/useAuth.tsx
+++ b/frontend/src/useAuth.tsx
@@ -10,12 +10,12 @@ import {
 } from "react";
 
 export type AuthUser = {
-  username: string;
+  email: string;
   [key: string]: unknown;
 };
 
 type LoginCredentials = {
-  username: string;
+  email: string;
   password: string;
 };
 
@@ -42,12 +42,12 @@ function parseUser(data: unknown): AuthUser | null {
   if (!data || typeof data !== "object") {
     return null;
   }
-  if ("username" in data && typeof (data as Record<string, unknown>).username === "string") {
+  if ("email" in data && typeof (data as Record<string, unknown>).email === "string") {
     return data as AuthUser;
   }
   if ("user" in data && typeof (data as Record<string, unknown>).user === "object") {
     const nested = (data as Record<string, unknown>).user as Record<string, unknown>;
-    if (typeof nested.username === "string") {
+    if (typeof nested.email === "string") {
       return nested as AuthUser;
     }
   }
@@ -138,7 +138,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
           "Content-Type": "application/json",
         },
         credentials: "include",
-        body: JSON.stringify(credentials),
+        body: JSON.stringify({
+          email: credentials.email,
+          password: credentials.password,
+        }),
       });
       if (!response.ok) {
         const message = await response.text().catch(() => "");


### PR DESCRIPTION
## Summary
- update auth context to use email for users and login credentials
- adjust login modal to collect and submit email values
- show the signed-in user's email in the header chip

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb0a65e8483268f6cddc8d7eb1b32