### PR TITLE
Persist SQLite data via Docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ backend/frontend_dist/*
 !backend/frontend_dist/index.html
 !backend/frontend_dist/.keep
 frontend/dist
+backend/data/
 .env
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ Każdy piksel można kliknąć, zobaczyć czy jest wolny czy zajęty i w przysz�
 
 - Domyślny plik bazy: `backend/data/pixels.db` (tworzony automatycznie przy starcie backendu).
 - Zmienna środowiskowa `PIXEL_DB_PATH` pozwala wskazać inną lokalizację pliku.
+- W `docker-compose.yml` katalog `data/` jest montowany jako named volume (`pixel-data`), dzięki czemu baza nie resetuje się po przebudowaniu obrazu Dockera.
 - Kopię zapasową najlepiej wykonywać po zatrzymaniu serwera (lub po `COMMIT`). Można też użyć polecenia `sqlite3 pixels.db ".backup backup.db"` na bieżącej instancji.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,8 @@ services:
     environment:
       - NODE_ENV=production
     restart: unless-stopped
+    volumes:
+      - pixel-data:/app/data
+
+volumes:
+  pixel-data:


### PR DESCRIPTION
## Summary
- mount the backend data directory as a named Docker volume so the SQLite database file survives image rebuilds
- ignore the generated backend/data directory in Git and document the new volume in the README

## Testing
- `docker compose config` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaabb74448326a83e2561516c9424