### PR TITLE
Add SMTP mailer implementation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,26 @@ Każdy piksel można kliknąć, zobaczyć czy jest wolny czy zajęty i w przysz�
 
 ## 🏗 Architektura
 
-- **Frontend**: React + TypeScript + Tailwind CSS  
-- **Backend**: Go (Gin framework) – API REST do obsługi pikseli  
+- **Frontend**: React + TypeScript + Tailwind CSS
+- **Backend**: Go (Gin framework) – API REST do obsługi pikseli
 - **Baza danych**: SQLite (plik tworzony domyślnie pod `backend/data/pixels.db`, można zmienić ścieżkę zmienną `PIXEL_DB_PATH`)
 - **Docker**: multi-stage build → jeden image z frontendem i backendem
 - **Nginx/Reverse Proxy**: opcjonalnie do hostingu na VPS + SSL
+
+### ✉️ Wysyłka e-maili
+
+Backend potrafi wysyłać realne wiadomości SMTP z linkami aktywacyjnymi. W środowisku deweloperskim, gdy konfiguracja SMTP nie jest ustawiona, serwer loguje treść wiadomości (ConsoleMailer). Aby aktywować transport SMTP ustaw poniższe zmienne środowiskowe:
+
+| Zmienna | Opis |
+| --- | --- |
+| `SMTP_HOST` | Adres serwera SMTP (np. `smtp.gmail.com`). |
+| `SMTP_PORT` | Port serwera SMTP (np. `587`). |
+| `SMTP_USERNAME` | Nazwa użytkownika konta SMTP (opcjonalna dla serwerów bez uwierzytelnienia, wymaga pary z hasłem). |
+| `SMTP_PASSWORD` | Hasło/APi key do konta SMTP. |
+| `SMTP_SENDER_EMAIL` | Adres nadawcy wiadomości (np. `noreply@twojadomena.pl`). |
+| `SMTP_SENDER_NAME` | (Opcjonalnie) nazwa wyświetlana nadawcy. Domyślnie `Kup Piksel`. |
+
+Jeśli dowolna z wymaganych wartości (`SMTP_HOST`, `SMTP_PORT`, `SMTP_SENDER_EMAIL`) jest pominięta, backend zapisze czytelny log i automatycznie wróci do trybu konsolowego.
 
 ### 💾 Przechowywanie danych backendu
 

--- a/backend/internal/email/smtp_mailer.go
+++ b/backend/internal/email/smtp_mailer.go
@@ -1,0 +1,179 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"mime"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strconv"
+	"strings"
+)
+
+// SMTPConfig contains configuration required to send transactional emails via SMTP.
+type SMTPConfig struct {
+	Host      string
+	Port      int
+	Username  string
+	Password  string
+	FromEmail string
+	FromName  string
+}
+
+func (c *SMTPConfig) sanitize() {
+	c.Host = strings.TrimSpace(c.Host)
+	c.Username = strings.TrimSpace(c.Username)
+	c.Password = strings.TrimSpace(c.Password)
+	c.FromEmail = strings.TrimSpace(c.FromEmail)
+	c.FromName = strings.TrimSpace(c.FromName)
+	if c.FromName == "" {
+		c.FromName = "Kup Piksel"
+	}
+}
+
+// Validate checks that the configuration contains mandatory fields.
+func (c *SMTPConfig) Validate() error {
+	if c == nil {
+		return errors.New("smtp config is nil")
+	}
+	if c.Host == "" {
+		return errors.New("SMTP host is required")
+	}
+	if c.Port <= 0 {
+		return errors.New("SMTP port must be a positive integer")
+	}
+	if c.FromEmail == "" {
+		return errors.New("SMTP sender email is required")
+	}
+	if (c.Username == "") != (c.Password == "") {
+		return errors.New("SMTP username and password must be provided together")
+	}
+	return nil
+}
+
+// Address returns the host:port pair for smtp.SendMail.
+func (c SMTPConfig) Address() string {
+	return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+}
+
+// LoadSMTPConfigFromEnv builds SMTP configuration using environment variables.
+// If no SMTP-related variables are present it returns (nil, nil).
+func LoadSMTPConfigFromEnv(getenv func(string) string) (*SMTPConfig, error) {
+	trim := func(key string) string { return strings.TrimSpace(getenv(key)) }
+
+	host := trim("SMTP_HOST")
+	portValue := trim("SMTP_PORT")
+	username := trim("SMTP_USERNAME")
+	password := trim("SMTP_PASSWORD")
+	fromEmail := trim("SMTP_SENDER_EMAIL")
+	fromName := trim("SMTP_SENDER_NAME")
+
+	if host == "" && portValue == "" && username == "" && password == "" && fromEmail == "" && fromName == "" {
+		return nil, nil
+	}
+	if host == "" {
+		return nil, errors.New("SMTP_HOST must be set when enabling SMTP mailer")
+	}
+	if portValue == "" {
+		return nil, errors.New("SMTP_PORT must be set when enabling SMTP mailer")
+	}
+
+	port, err := strconv.Atoi(portValue)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SMTP_PORT value %q: %w", portValue, err)
+	}
+
+	cfg := &SMTPConfig{
+		Host:      host,
+		Port:      port,
+		Username:  username,
+		Password:  password,
+		FromEmail: fromEmail,
+		FromName:  fromName,
+	}
+	cfg.sanitize()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+var smtpSendMailFunc = smtp.SendMail
+
+// SMTPMailer delivers emails through a configured SMTP transport.
+type SMTPMailer struct {
+	config   SMTPConfig
+	auth     smtp.Auth
+	sendMail func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
+}
+
+// NewSMTPMailer constructs a Mailer using real SMTP transport.
+func NewSMTPMailer(cfg SMTPConfig) (*SMTPMailer, error) {
+	cfg.sanitize()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	var auth smtp.Auth
+	if cfg.Username != "" {
+		auth = smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+	}
+
+	return &SMTPMailer{
+		config:   cfg,
+		auth:     auth,
+		sendMail: smtpSendMailFunc,
+	}, nil
+}
+
+// SendVerificationEmail sends an activation email with a verification link.
+func (m *SMTPMailer) SendVerificationEmail(ctx context.Context, recipient, verificationLink string) error {
+	if m == nil {
+		return errors.New("smtp mailer is nil")
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	recipient = strings.TrimSpace(recipient)
+	if recipient == "" {
+		return errors.New("recipient must not be empty")
+	}
+	if _, err := mail.ParseAddress(recipient); err != nil {
+		return fmt.Errorf("invalid recipient: %w", err)
+	}
+
+	verificationLink = strings.TrimSpace(verificationLink)
+	if verificationLink == "" {
+		return errors.New("verification link must not be empty")
+	}
+
+	from := mail.Address{Name: m.config.FromName, Address: m.config.FromEmail}
+	to := mail.Address{Address: recipient}
+
+	subject := "Potwierdź swój adres e-mail"
+	encodedSubject := mime.QEncoding.Encode("utf-8", subject)
+	body := fmt.Sprintf("Cześć!\n\nKliknij poniższy link, aby potwierdzić swoje konto w Kup Piksel:\n%s\n\nJeżeli to nie Ty zakładałeś konto, zignoruj tę wiadomość.\n", verificationLink)
+
+	var msg bytes.Buffer
+	msg.WriteString(fmt.Sprintf("From: %s\r\n", from.String()))
+	msg.WriteString(fmt.Sprintf("To: %s\r\n", to.String()))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", encodedSubject))
+	msg.WriteString("MIME-Version: 1.0\r\n")
+	msg.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	msg.WriteString("Content-Transfer-Encoding: 8bit\r\n")
+	msg.WriteString("\r\n")
+	msg.WriteString(body)
+
+	if err := m.sendMail(m.config.Address(), m.auth, m.config.FromEmail, []string{recipient}, msg.Bytes()); err != nil {
+		return fmt.Errorf("send smtp email: %w", err)
+	}
+	return nil
+}
+
+var _ Mailer = (*SMTPMailer)(nil)

--- a/backend/internal/email/smtp_mailer_test.go
+++ b/backend/internal/email/smtp_mailer_test.go
@@ -1,0 +1,111 @@
+package email
+
+import (
+	"context"
+	"net/smtp"
+	"strings"
+	"testing"
+)
+
+func TestLoadSMTPConfigFromEnv(t *testing.T) {
+	t.Run("no config", func(t *testing.T) {
+		cfg, err := LoadSMTPConfigFromEnv(func(string) string { return "" })
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg != nil {
+			t.Fatalf("expected nil config, got %#v", cfg)
+		}
+	})
+
+	t.Run("missing host", func(t *testing.T) {
+		_, err := LoadSMTPConfigFromEnv(func(key string) string {
+			switch key {
+			case "SMTP_PORT":
+				return "25"
+			case "SMTP_SENDER_EMAIL":
+				return "noreply@example.com"
+			default:
+				return ""
+			}
+		})
+		if err == nil {
+			t.Fatalf("expected error when host missing")
+		}
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		cfg, err := LoadSMTPConfigFromEnv(func(key string) string {
+			switch key {
+			case "SMTP_HOST":
+				return "smtp.example.com"
+			case "SMTP_PORT":
+				return "587"
+			case "SMTP_USERNAME":
+				return "user"
+			case "SMTP_PASSWORD":
+				return "secret"
+			case "SMTP_SENDER_EMAIL":
+				return "noreply@example.com"
+			default:
+				return ""
+			}
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg == nil {
+			t.Fatalf("expected config, got nil")
+		}
+		if cfg.FromName != "Kup Piksel" {
+			t.Fatalf("expected default from name, got %q", cfg.FromName)
+		}
+	})
+}
+
+func TestSMTPMailerSendVerificationEmail(t *testing.T) {
+	cfg := SMTPConfig{
+		Host:      "smtp.example.com",
+		Port:      587,
+		FromEmail: "noreply@example.com",
+		FromName:  "Kup Piksel",
+	}
+	mailer, err := NewSMTPMailer(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var capturedAddr string
+	var capturedFrom string
+	var capturedTo []string
+	var capturedMsg []byte
+	mailer.sendMail = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		capturedAddr = addr
+		capturedFrom = from
+		capturedTo = append([]string(nil), to...)
+		capturedMsg = append([]byte(nil), msg...)
+		return nil
+	}
+
+	ctx := context.Background()
+	err = mailer.SendVerificationEmail(ctx, "user@example.com", "https://kup-piksel.test/verify?token=abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedAddr == "" {
+		t.Fatalf("expected sendMail to be called")
+	}
+	if capturedFrom != cfg.FromEmail {
+		t.Fatalf("unexpected from address: %q", capturedFrom)
+	}
+	if len(capturedTo) != 1 || capturedTo[0] != "user@example.com" {
+		t.Fatalf("unexpected recipients: %#v", capturedTo)
+	}
+	if !strings.Contains(string(capturedMsg), "https://kup-piksel.test/verify?token=abc") {
+		t.Fatalf("message should contain verification link")
+	}
+	lowerMsg := strings.ToLower(string(capturedMsg))
+	if !strings.Contains(lowerMsg, "subject: =?utf-8?q?potwierd=c5=ba_sw=c3=b3j_adres_e-mail?=") {
+		t.Fatalf("subject should be encoded, got %s", string(capturedMsg))
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -253,10 +253,25 @@ func main() {
 		verificationBaseURL = defaultVerificationBaseURL
 	}
 
+	var mailer email.Mailer = email.NewConsoleMailer("Kup Piksel")
+	if cfg, err := email.LoadSMTPConfigFromEnv(os.Getenv); err != nil {
+		log.Printf("smtp configuration invalid: %v", err)
+		log.Printf("falling back to console mailer")
+	} else if cfg != nil {
+		smtpMailer, err := email.NewSMTPMailer(*cfg)
+		if err != nil {
+			log.Printf("failed to initialise smtp mailer: %v", err)
+			log.Printf("falling back to console mailer")
+		} else {
+			mailer = smtpMailer
+			log.Printf("smtp mailer enabled for %s", cfg.Address())
+		}
+	}
+
 	server := &Server{
 		store:                store,
 		sessions:             NewSessionManager(),
-		mailer:               email.NewConsoleMailer("Kup Piksel"),
+		mailer:               mailer,
 		verificationBaseURL:  verificationBaseURL,
 		verificationTokenTTL: defaultVerificationTTL,
 	}

--- a/user_guide.md
+++ b/user_guide.md
@@ -55,6 +55,24 @@ Możesz uruchomić frontend i backend osobno, aby mieć szybkie odświeżanie ko
    ```
    Backend nasłuchuje na `http://localhost:3000`.
 
+#### Konfiguracja SMTP
+
+Aby włączyć wysyłkę prawdziwych wiadomości aktywacyjnych skonfiguruj zmienne środowiskowe przed startem serwera:
+
+```bash
+export SMTP_HOST="smtp.example.com"
+export SMTP_PORT="587"
+export SMTP_USERNAME="apikey"
+export SMTP_PASSWORD="sekret"
+export SMTP_SENDER_EMAIL="noreply@example.com"
+export SMTP_SENDER_NAME="Kup Piksel"
+go run .
+```
+
+Jeżeli konfiguracja jest niepełna backend wypisze czytelny log i przełączy się na tryb konsolowy (link aktywacyjny w logach). Dzięki temu łatwo wychwycić brakujące dane konfiguracyjne.
+
+> 💡 Do lokalnych testów polecamy [MailHog](https://github.com/mailhog/MailHog): `docker run --rm -p 1025:1025 -p 8025:8025 mailhog/mailhog`. Ustaw `SMTP_HOST=localhost` oraz `SMTP_PORT=1025`, a odebrane wiadomości zobaczysz w przeglądarce pod `http://localhost:8025`.
+
 ### 3.2 Frontend (Vite)
 1. Zainstaluj paczki NPM:
    ```bash
@@ -75,6 +93,13 @@ Możesz uruchomić frontend i backend osobno, aby mieć szybkie odświeżanie ko
        -H "Content-Type: application/json" \
        -d '{"id":42,"status":"taken","color":"#123456","url":"https://example.com"}'
   ```
+- **Test wysyłki e-mail**: po uruchomieniu backendu z konfiguracją SMTP zarejestruj konto testowe:
+  ```bash
+  curl -X POST http://localhost:3000/api/register \
+       -H "Content-Type: application/json" \
+       -d '{"email":"test@example.com","password":"Test1234!"}'
+  ```
+  W logach serwera (ConsoleMailer) lub w panelu MailHog zobaczysz wiadomość aktywacyjną z linkiem weryfikacyjnym.
 
 > ℹ️ Po zmianie frontendu warto wykonać `npm run build` (patrz sekcja 4), by upewnić się że kompilacja produkcyjna przechodzi bez błędów.
 


### PR DESCRIPTION
## Summary
- add a production-ready SMTP mailer with validation and tests
- wire dynamic mailer selection in main with clear logging for misconfiguration
- document SMTP environment variables and describe how to send a test activation email

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cdb8e9618c8326926785178056fe00