### PR TITLE
Add JSON config loader and email verification toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,18 @@ Każdy piksel można kliknąć, zobaczyć czy jest wolny czy zajęty i w przysz�
 - **Docker**: multi-stage build → jeden image z frontendem i backendem
 - **Nginx/Reverse Proxy**: opcjonalnie do hostingu na VPS + SSL
 
-### ✉️ Wysyłka e-maili
+### ✉️ Konfiguracja backendu
 
-Backend potrafi wysyłać realne wiadomości SMTP z linkami aktywacyjnymi. W środowisku deweloperskim, gdy konfiguracja SMTP nie jest ustawiona, serwer loguje treść wiadomości (ConsoleMailer). Aby aktywować transport SMTP ustaw poniższe zmienne środowiskowe:
+Backend odczytuje ustawienia z pliku `config.json` (domyślnie w katalogu `backend/`, ścieżkę można nadpisać zmienną `PIXEL_CONFIG_PATH`). Format pliku to JSON/JSON5 – możesz korzystać z komentarzy i końcowych przecinków. Przykładowy plik znajdziesz pod `backend/config.example.json`.
 
-| Zmienna | Opis |
+Kluczowe opcje:
+
+| Pole | Opis |
 | --- | --- |
-| `SMTP_HOST` | Adres serwera SMTP (np. `smtp.gmail.com`). |
-| `SMTP_PORT` | Port serwera SMTP (np. `587`). |
-| `SMTP_USERNAME` | Nazwa użytkownika konta SMTP (opcjonalna dla serwerów bez uwierzytelnienia, wymaga pary z hasłem). |
-| `SMTP_PASSWORD` | Hasło/APi key do konta SMTP. |
-| `SMTP_SENDER_EMAIL` | Adres nadawcy wiadomości (np. `noreply@twojadomena.pl`). |
-| `SMTP_SENDER_NAME` | (Opcjonalnie) nazwa wyświetlana nadawcy. Domyślnie `Kup Piksel`. |
+| `disableVerificationEmail` | Po ustawieniu na `true` nowi użytkownicy są automatycznie oznaczani jako zweryfikowani i nie są wysyłane żadne maile. |
+| `smtp` | (Opcjonalnie) konfiguracja transportu SMTP oparta na polach `host`, `port`, `username`, `password`, `fromEmail`, `fromName`. |
 
-Jeśli dowolna z wymaganych wartości (`SMTP_HOST`, `SMTP_PORT`, `SMTP_SENDER_EMAIL`) jest pominięta, backend zapisze czytelny log i automatycznie wróci do trybu konsolowego.
+Jeżeli sekcja `smtp` jest pominięta lub pusta, backend pozostaje w trybie developerskim – link aktywacyjny pojawia się w logach (ConsoleMailer). Po poprawnym uzupełnieniu danych zostanie użyty prawdziwy serwer SMTP.
 
 ### 💾 Przechowywanie danych backendu
 

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -1,0 +1,13 @@
+{
+  // Set to true to automatically mark newly created accounts as verified and skip emails.
+  "disableVerificationEmail": false,
+  // Configure SMTP to deliver verification emails. Leave the object empty or remove it to use the console mailer.
+  "smtp": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "username": "smtp-user",
+    "password": "smtp-password",
+    "fromEmail": "noreply@example.com",
+    "fromName": "Kup Piksel"
+  }
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,9 +3,9 @@ module github.com/example/kup-piksel
 go 1.21
 
 require (
-	github.com/gin-gonic/gin v0.0.0
-	github.com/mattn/go-sqlite3 v1.14.22
-	golang.org/x/crypto/bcrypt v0.0.0
+        github.com/gin-gonic/gin v0.0.0
+        github.com/mattn/go-sqlite3 v1.14.22
+        golang.org/x/crypto/bcrypt v0.0.0
 )
 
 replace github.com/gin-gonic/gin => ./internal/ginlite

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/example/kup-piksel/internal/email"
+)
+
+// Config represents backend configuration options loaded from disk.
+type Config struct {
+	SMTP                     *email.SMTPConfig `json:"smtp"`
+	DisableVerificationEmail bool              `json:"disableVerificationEmail"`
+}
+
+// Load reads the configuration from a JSON or JSON5 file located at the given path.
+func Load(path string) (*Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("config path must not be empty")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open config file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+
+	normalized := normalizeJSON5(data)
+
+	var cfg Config
+	if err := json.Unmarshal(normalized, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	if cfg.SMTP != nil {
+		cfg.SMTP.Sanitize()
+		if err := cfg.SMTP.Validate(); err != nil {
+			return nil, fmt.Errorf("smtp: %w", err)
+		}
+	}
+
+	return &cfg, nil
+}
+
+func normalizeJSON5(input []byte) []byte {
+	withoutComments := stripJSONComments(input)
+	return removeTrailingCommas(withoutComments)
+}
+
+func stripJSONComments(input []byte) []byte {
+	var buf bytes.Buffer
+	inString := false
+	escaped := false
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		if inString {
+			buf.WriteByte(ch)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		if ch == '"' {
+			inString = true
+			buf.WriteByte(ch)
+			continue
+		}
+
+		if ch == '/' && i+1 < len(input) {
+			next := input[i+1]
+			if next == '/' {
+				i += 2
+				for i < len(input) && input[i] != '\n' && input[i] != '\r' {
+					i++
+				}
+				buf.WriteByte('\n')
+				continue
+			}
+			if next == '*' {
+				i += 2
+				for i+1 < len(input) && !(input[i] == '*' && input[i+1] == '/') {
+					i++
+				}
+				i++
+				continue
+			}
+		}
+
+		buf.WriteByte(ch)
+	}
+	return buf.Bytes()
+}
+
+func removeTrailingCommas(input []byte) []byte {
+	var buf bytes.Buffer
+	inString := false
+	escaped := false
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		if inString {
+			buf.WriteByte(ch)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		if ch == '"' {
+			inString = true
+			buf.WriteByte(ch)
+			continue
+		}
+
+		if ch == ',' {
+			j := i + 1
+			for j < len(input) {
+				if input[j] == ' ' || input[j] == '\n' || input[j] == '\r' || input[j] == '\t' {
+					j++
+					continue
+				}
+				break
+			}
+			if j < len(input) && (input[j] == '}' || input[j] == ']') {
+				continue
+			}
+		}
+
+		buf.WriteByte(ch)
+	}
+	return buf.Bytes()
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/example/kup-piksel/internal/email"
+)
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}
+
+func TestLoad_DisableVerificationWithoutSMTP(t *testing.T) {
+	path := writeTempConfig(t, `{
+                // JSON5 style comment should be accepted
+                "disableVerificationEmail": true,
+        }`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config instance, got nil")
+	}
+	if cfg.DisableVerificationEmail != true {
+		t.Fatalf("expected DisableVerificationEmail to be true, got %v", cfg.DisableVerificationEmail)
+	}
+	if cfg.SMTP != nil {
+		t.Fatalf("expected SMTP to be nil, got %#v", cfg.SMTP)
+	}
+}
+
+func TestLoad_WithValidSMTP(t *testing.T) {
+	path := writeTempConfig(t, `{
+                "smtp": {
+                        "host": "smtp.example.com",
+                        "port": 587,
+                        "username": " user ",
+                        "password": " secret ",
+                        "fromEmail": "noreply@example.com",
+                        "fromName": "  Team  "
+                }
+        }`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.SMTP == nil {
+		t.Fatal("expected SMTP configuration")
+	}
+	expected := &email.SMTPConfig{
+		Host:      "smtp.example.com",
+		Port:      587,
+		Username:  "user",
+		Password:  "secret",
+		FromEmail: "noreply@example.com",
+		FromName:  "Team",
+	}
+	if *cfg.SMTP != *expected {
+		t.Fatalf("unexpected SMTP configuration: %#v", cfg.SMTP)
+	}
+}
+
+func TestLoad_InvalidSMTP(t *testing.T) {
+	path := writeTempConfig(t, `{
+                "smtp": {
+                        "host": "",
+                        "port": 587,
+                        "fromEmail": "noreply@example.com"
+                }
+        }`)
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error when SMTP is invalid")
+	}
+}
+
+func TestLoad_MissingPath(t *testing.T) {
+	if _, err := Load(" "); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}

--- a/backend/internal/email/smtp_mailer.go
+++ b/backend/internal/email/smtp_mailer.go
@@ -23,7 +23,8 @@ type SMTPConfig struct {
 	FromName  string
 }
 
-func (c *SMTPConfig) sanitize() {
+// Sanitize trims whitespace from configuration fields and applies defaults.
+func (c *SMTPConfig) Sanitize() {
 	c.Host = strings.TrimSpace(c.Host)
 	c.Username = strings.TrimSpace(c.Username)
 	c.Password = strings.TrimSpace(c.Password)
@@ -94,7 +95,7 @@ func LoadSMTPConfigFromEnv(getenv func(string) string) (*SMTPConfig, error) {
 		FromEmail: fromEmail,
 		FromName:  fromName,
 	}
-	cfg.sanitize()
+	cfg.Sanitize()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ type SMTPMailer struct {
 
 // NewSMTPMailer constructs a Mailer using real SMTP transport.
 func NewSMTPMailer(cfg SMTPConfig) (*SMTPMailer, error) {
-	cfg.sanitize()
+	cfg.Sanitize()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}

--- a/backend/main_register_test.go
+++ b/backend/main_register_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gin "github.com/gin-gonic/gin"
+
+	"github.com/example/kup-piksel/internal/email"
+	"github.com/example/kup-piksel/internal/storage/sqlite"
+)
+
+type fakeMailer struct {
+	sent int
+}
+
+func (f *fakeMailer) SendVerificationEmail(ctx context.Context, recipient, verificationLink string) error {
+	f.sent++
+	return nil
+}
+
+var _ email.Mailer = (*fakeMailer)(nil)
+
+func TestHandleRegister_DisableVerificationEmail(t *testing.T) {
+	store, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if err := store.EnsureSchema(context.Background()); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+
+	mailer := &fakeMailer{}
+	server := &Server{
+		store:                    store,
+		sessions:                 NewSessionManager(),
+		mailer:                   mailer,
+		verificationBaseURL:      "http://example.com",
+		verificationTokenTTL:     time.Hour,
+		disableVerificationEmail: true,
+	}
+
+	body := bytes.NewBufferString(`{"email":"user@example.com","password":"strong"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/register", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c := &gin.Context{Writer: w, Request: req}
+
+	server.handleRegister(c)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+	if mailer.sent != 0 {
+		t.Fatalf("expected no verification emails to be sent, got %d", mailer.sent)
+	}
+
+	user, err := store.GetUserByEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if !user.IsVerified {
+		t.Fatalf("expected user to be verified")
+	}
+}

--- a/user_guide.md
+++ b/user_guide.md
@@ -55,23 +55,22 @@ Możesz uruchomić frontend i backend osobno, aby mieć szybkie odświeżanie ko
    ```
    Backend nasłuchuje na `http://localhost:3000`.
 
-#### Konfiguracja SMTP
+#### Konfiguracja backendu
 
-Aby włączyć wysyłkę prawdziwych wiadomości aktywacyjnych skonfiguruj zmienne środowiskowe przed startem serwera:
+Ustawienia serwera znajdują się w pliku `backend/config.json` (format JSON/JSON5). Możesz rozpocząć od skopiowania przykładu:
 
 ```bash
-export SMTP_HOST="smtp.example.com"
-export SMTP_PORT="587"
-export SMTP_USERNAME="apikey"
-export SMTP_PASSWORD="sekret"
-export SMTP_SENDER_EMAIL="noreply@example.com"
-export SMTP_SENDER_NAME="Kup Piksel"
-go run .
+cp backend/config.example.json backend/config.json
 ```
 
-Jeżeli konfiguracja jest niepełna backend wypisze czytelny log i przełączy się na tryb konsolowy (link aktywacyjny w logach). Dzięki temu łatwo wychwycić brakujące dane konfiguracyjne.
+Najważniejsze parametry:
 
-> 💡 Do lokalnych testów polecamy [MailHog](https://github.com/mailhog/MailHog): `docker run --rm -p 1025:1025 -p 8025:8025 mailhog/mailhog`. Ustaw `SMTP_HOST=localhost` oraz `SMTP_PORT=1025`, a odebrane wiadomości zobaczysz w przeglądarce pod `http://localhost:8025`.
+- `disableVerificationEmail` – ustaw na `true`, jeśli w środowisku testowym chcesz pomijać wysyłkę maili i automatycznie weryfikować konta.
+- `smtp` – sekcja z danymi serwera SMTP (`host`, `port`, `username`, `password`, `fromEmail`, `fromName`). Pozostaw pustą lub usuń, aby backend korzystał z trybu konsolowego (link w logach).
+
+Ścieżkę do pliku konfiguracyjnego można nadpisać zmienną środowiskową `PIXEL_CONFIG_PATH`. To przydatne np. w Dockerze lub podczas uruchamiania wielu instancji.
+
+> 💡 Do lokalnych testów SMTP polecamy [MailHog](https://github.com/mailhog/MailHog): `docker run --rm -p 1025:1025 -p 8025:8025 mailhog/mailhog`. Skonfiguruj `host` = `localhost`, `port` = `1025`, a odebrane wiadomości zobaczysz w przeglądarce pod `http://localhost:8025`.
 
 ### 3.2 Frontend (Vite)
 1. Zainstaluj paczki NPM:
@@ -93,7 +92,7 @@ Jeżeli konfiguracja jest niepełna backend wypisze czytelny log i przełączy s
        -H "Content-Type: application/json" \
        -d '{"id":42,"status":"taken","color":"#123456","url":"https://example.com"}'
   ```
-- **Test wysyłki e-mail**: po uruchomieniu backendu z konfiguracją SMTP zarejestruj konto testowe:
+- **Test wysyłki e-mail**: po uzupełnieniu sekcji `smtp` w pliku konfiguracyjnym zarejestruj konto testowe:
   ```bash
   curl -X POST http://localhost:3000/api/register \
        -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- add a backend configuration loader that reads JSON/JSON5 files, validates SMTP settings and exposes the disableVerificationEmail flag
- wire the new configuration into the server startup, falling back to the console mailer when SMTP is missing, and short-circuit verification flows when emails are disabled
- update registration logic, documentation and add unit tests plus a sample config file demonstrating the new options

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cdc6a838fc8326a11d9ffb43fbea99