### PR TITLE
Ensure default configuration is generated

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -18,6 +18,31 @@ type Config struct {
 	DisableVerificationEmail bool              `json:"disableVerificationEmail"`
 }
 
+// Default returns the configuration used when no config file exists on disk yet.
+func Default() *Config {
+	return &Config{DisableVerificationEmail: true}
+}
+
+// WriteFile writes the given configuration as prettified JSON to the provided path.
+func WriteFile(path string, cfg *Config) error {
+	if cfg == nil {
+		return errors.New("config must not be nil")
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	data = append(data, '\n')
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write config file: %w", err)
+	}
+
+	return nil
+}
+
 // Load reads the configuration from a JSON or JSON5 file located at the given path.
 func Load(path string) (*Config, error) {
 	if strings.TrimSpace(path) == "" {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -90,3 +90,33 @@ func TestLoad_MissingPath(t *testing.T) {
 		t.Fatal("expected error for empty path")
 	}
 }
+
+func TestWriteFile_DefaultConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file to not exist, got: %v", err)
+	}
+
+	if err := WriteFile(path, Default()); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file to exist, got: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.DisableVerificationEmail != true {
+		t.Fatalf("expected DisableVerificationEmail to be true, got %v", cfg.DisableVerificationEmail)
+	}
+
+	if cfg.SMTP != nil {
+		t.Fatalf("expected SMTP to be nil, got %#v", cfg.SMTP)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -228,6 +228,21 @@ func main() {
 		configPath = defaultConfigPath
 	}
 
+	if _, err := os.Stat(configPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if dir := filepath.Dir(configPath); dir != "" && dir != "." {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					log.Fatalf("create config directory: %v", err)
+				}
+			}
+			if err := config.WriteFile(configPath, config.Default()); err != nil {
+				log.Fatalf("write default config: %v", err)
+			}
+		} else {
+			log.Fatalf("stat config: %v", err)
+		}
+	}
+
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		log.Fatalf("load config: %v", err)


### PR DESCRIPTION
## Summary
- add helpers to provide and write the default backend configuration
- generate a config file with defaults when none is present before loading it
- add tests that verify the default configuration file creation and loading

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cdcdf85f7083269e57cfa42a977efa