### PR TITLE
Set verification emails enabled by default

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 
 // Default returns the configuration used when no config file exists on disk yet.
 func Default() *Config {
-	return &Config{DisableVerificationEmail: true}
+	return &Config{DisableVerificationEmail: false}
 }
 
 // WriteFile writes the given configuration as prettified JSON to the provided path.

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -31,7 +31,7 @@ func TestLoad_DisableVerificationWithoutSMTP(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("expected config instance, got nil")
 	}
-	if cfg.DisableVerificationEmail != true {
+	if !cfg.DisableVerificationEmail {
 		t.Fatalf("expected DisableVerificationEmail to be true, got %v", cfg.DisableVerificationEmail)
 	}
 	if cfg.SMTP != nil {
@@ -112,8 +112,8 @@ func TestWriteFile_DefaultConfig(t *testing.T) {
 		t.Fatalf("Load returned error: %v", err)
 	}
 
-	if cfg.DisableVerificationEmail != true {
-		t.Fatalf("expected DisableVerificationEmail to be true, got %v", cfg.DisableVerificationEmail)
+	if cfg.DisableVerificationEmail {
+		t.Fatalf("expected DisableVerificationEmail to be false, got %v", cfg.DisableVerificationEmail)
 	}
 
 	if cfg.SMTP != nil {


### PR DESCRIPTION
## Summary
- update the backend default configuration to keep verification emails enabled
- adjust configuration tests to reflect the new default behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cde9a0cc048326b85d812064cf1ae9