### PR TITLE
Ensure container config availability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ FROM alpine:3.19
 WORKDIR /app
 RUN apk add --no-cache sqlite-libs
 COPY --from=backend-builder /app/backend/kup-piksel ./kup-piksel
+COPY backend/config.example.json ./config.json
 EXPOSE 3000
 CMD ["./kup-piksel"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     restart: unless-stopped
     volumes:
       - pixel-data:/app/data
+      - ./backend/config.json:/app/config.json:ro
 
 volumes:
   pixel-data:


### PR DESCRIPTION
## Summary
- copy the backend configuration template into /app/config.json in the runtime image so SMTP settings are available by default
- mount backend/config.json into /app/config.json via docker-compose to allow operators to supply secrets at runtime

## Testing
- docker compose build *(fails: docker not installed in environment)*
- docker compose up *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdedc771e88326b63df7b03c339af8