### PR TITLE
Fix bcrypt salt handling and add tests

### DIFF
--- a/backend/internal/bcrypt/bcrypt.go
+++ b/backend/internal/bcrypt/bcrypt.go
@@ -58,7 +58,8 @@ func CompareHashAndPassword(hashedPassword, password []byte) error {
 		return ErrHashTooShort
 	}
 
-	salt := decoded[:saltSize]
+	salt := make([]byte, saltSize)
+	copy(salt, decoded[:saltSize])
 	storedDigest := decoded[saltSize:]
 	digest := sha256.Sum256(append(salt, password...))
 	if subtle.ConstantTimeCompare(storedDigest, digest[:]) != 1 {

--- a/backend/internal/bcrypt/bcrypt_test.go
+++ b/backend/internal/bcrypt/bcrypt_test.go
@@ -1,0 +1,31 @@
+package bcrypt
+
+import "testing"
+
+func TestGenerateFromPasswordRoundTrip(t *testing.T) {
+	password := []byte("correct horse battery staple")
+	hash, err := GenerateFromPassword(password, DefaultCost)
+	if err != nil {
+		t.Fatalf("GenerateFromPassword error: %v", err)
+	}
+
+	if err := CompareHashAndPassword(hash, password); err != nil {
+		t.Fatalf("CompareHashAndPassword mismatch: %v", err)
+	}
+}
+
+func TestCompareHashAndPasswordRejectsWrongPassword(t *testing.T) {
+	password := []byte("p@ssw0rd")
+	hash, err := GenerateFromPassword(password, DefaultCost)
+	if err != nil {
+		t.Fatalf("GenerateFromPassword error: %v", err)
+	}
+
+	wrong := []byte("not-the-password")
+	if err := CompareHashAndPassword(hash, wrong); err != ErrMismatchedHashAndPassword {
+		if err == nil {
+			t.Fatal("CompareHashAndPassword accepted wrong password")
+		}
+		t.Fatalf("CompareHashAndPassword returned unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- copy the stored salt before hashing in CompareHashAndPassword to avoid mutating the decoded buffer
- add unit tests that exercise successful and failing password comparisons

## Testing
- go test ./... (from backend/internal/bcrypt)
- go test ./... -run TestHandleLogin -v (from backend)


------
https://chatgpt.com/codex/tasks/task_e_68cee918262083269931085bf76c9fba