### PR TITLE
Fix update pixel transaction rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ backend/frontend_dist/*
 !backend/frontend_dist/assets/
 !backend/frontend_dist/assets/**
 frontend/dist
+frontend/dist-tests
 backend/data/
 .env
 .DS_Store

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -1,4 +1,6 @@
 {
+  // Number of points required to claim a pixel.
+  "pixelCostPoints": 10,
   // Set to true to automatically mark newly created accounts as verified and skip emails.
   "disableVerificationEmail": false,
   // Configure SMTP to deliver verification emails. Leave the object empty or remove it to use the console mailer.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -16,11 +16,12 @@ import (
 type Config struct {
 	SMTP                     *email.SMTPConfig `json:"smtp"`
 	DisableVerificationEmail bool              `json:"disableVerificationEmail"`
+	PixelCostPoints          int               `json:"pixelCostPoints"`
 }
 
 // Default returns the configuration used when no config file exists on disk yet.
 func Default() *Config {
-	return &Config{DisableVerificationEmail: false}
+	return &Config{DisableVerificationEmail: false, PixelCostPoints: 10}
 }
 
 // WriteFile writes the given configuration as prettified JSON to the provided path.
@@ -72,6 +73,10 @@ func Load(path string) (*Config, error) {
 		if err := cfg.SMTP.Validate(); err != nil {
 			return nil, fmt.Errorf("smtp: %w", err)
 		}
+	}
+
+	if cfg.PixelCostPoints <= 0 {
+		cfg.PixelCostPoints = Default().PixelCostPoints
 	}
 
 	return &cfg, nil

--- a/backend/main.go
+++ b/backend/main.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -44,6 +45,7 @@ type Server struct {
 	verificationBaseURL      string
 	verificationTokenTTL     time.Duration
 	disableVerificationEmail bool
+	pixelCostPoints          int64
 }
 
 type SessionManager struct {
@@ -102,6 +104,7 @@ type userResponse struct {
 	Email      string     `json:"email"`
 	IsVerified bool       `json:"is_verified"`
 	VerifiedAt *time.Time `json:"verified_at,omitempty"`
+	Points     int64      `json:"points"`
 }
 
 const (
@@ -112,6 +115,8 @@ const (
 	defaultVerificationTTL     = 24 * time.Hour
 	defaultConfigPath          = "config.json"
 )
+
+var activationCodePattern = regexp.MustCompile(`^[A-Z0-9]{4}(?:-[A-Z0-9]{4}){3}$`)
 
 func generateSessionID() (string, error) {
 	buf := make([]byte, 32)
@@ -159,7 +164,13 @@ func readSessionCookie(r *http.Request) (string, bool, error) {
 }
 
 func sanitizeUser(user sqlite.User) userResponse {
-	return userResponse{ID: user.ID, Email: user.Email, IsVerified: user.IsVerified, VerifiedAt: user.VerifiedAt}
+	return userResponse{
+		ID:         user.ID,
+		Email:      user.Email,
+		IsVerified: user.IsVerified,
+		VerifiedAt: user.VerifiedAt,
+		Points:     user.Points,
+	}
 }
 
 func generateVerificationToken() (string, error) {
@@ -249,6 +260,12 @@ func main() {
 	}
 	log.Printf("loaded config from %s", configPath)
 
+	pixelCost := cfg.PixelCostPoints
+	if pixelCost <= 0 {
+		pixelCost = config.Default().PixelCostPoints
+	}
+	log.Printf("pixel cost configured at %d points", pixelCost)
+
 	dbPath := os.Getenv("PIXEL_DB_PATH")
 	if dbPath == "" {
 		dbPath = defaultDBPath
@@ -313,15 +330,17 @@ func main() {
 		verificationBaseURL:      verificationBaseURL,
 		verificationTokenTTL:     defaultVerificationTTL,
 		disableVerificationEmail: cfg.DisableVerificationEmail,
+		pixelCostPoints:          int64(pixelCost),
 	}
 
 	log.Printf(
-		"startup config: config_path=%s db_path=%s verification_base_url=%s smtp_configured=%t disable_verification_email=%t",
+		"startup config: config_path=%s db_path=%s verification_base_url=%s smtp_configured=%t disable_verification_email=%t pixel_cost_points=%d",
 		configPath,
 		dbPath,
 		verificationBaseURL,
 		smtpConfigured,
 		cfg.DisableVerificationEmail,
+		pixelCost,
 	)
 
 	router.POST("/api/register", server.handleRegister)
@@ -329,6 +348,7 @@ func main() {
 	router.POST("/api/logout", server.handleLogout)
 	router.GET("/api/session", server.handleSession)
 	router.GET("/api/account", server.handleAccount)
+	router.POST("/api/activation-codes/redeem", server.handleRedeemActivationCode)
 	router.GET("/api/verify", server.handleVerifyAccount)
 	router.POST("/api/resend-verification", server.handleResendVerification)
 
@@ -557,7 +577,7 @@ func (s *Server) handleLogin(c *gin.Context) {
 	}
 	setSessionCookie(c, sessionID)
 
-	c.JSON(http.StatusOK, gin.H{"user": sanitizeUser(user)})
+	c.JSON(http.StatusOK, gin.H{"user": sanitizeUser(user), "pixel_cost_points": s.pixelCostPoints})
 }
 
 func (s *Server) issueVerificationToken(ctx context.Context, user sqlite.User) (string, error) {
@@ -727,10 +747,10 @@ func (s *Server) handleSession(c *gin.Context) {
 			s.sessions.Delete(sessionID)
 			clearSessionCookie(c)
 		}
-		c.JSON(http.StatusOK, gin.H{"user": nil})
+		c.JSON(http.StatusOK, gin.H{"user": nil, "pixel_cost_points": s.pixelCostPoints})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": sanitizeUser(user)})
+	c.JSON(http.StatusOK, gin.H{"user": sanitizeUser(user), "pixel_cost_points": s.pixelCostPoints})
 }
 
 func (s *Server) handleAccount(c *gin.Context) {
@@ -747,8 +767,47 @@ func (s *Server) handleAccount(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"user":   sanitizeUser(user),
-		"pixels": pixels,
+		"user":              sanitizeUser(user),
+		"pixels":            pixels,
+		"pixel_cost_points": s.pixelCostPoints,
+	})
+}
+
+func (s *Server) handleRedeemActivationCode(c *gin.Context) {
+	user, ok := s.requireUser(c)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Code string `json:"code"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		return
+	}
+
+	code := strings.ToUpper(strings.TrimSpace(req.Code))
+	if !activationCodePattern.MatchString(code) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "nieprawidłowy format kodu. Użyj xxxx-xxxx-xxxx-xxxx."})
+		return
+	}
+
+	updatedUser, added, err := s.store.RedeemActivationCode(c.Request.Context(), user.ID, code)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "kod nie istnieje lub został już wykorzystany."})
+			return
+		}
+		log.Printf("redeem activation code %s for user %d: %v", code, user.ID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "nie udało się aktywować kodu"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"user":              sanitizeUser(updatedUser),
+		"added_points":      added,
+		"pixel_cost_points": s.pixelCostPoints,
 	})
 }
 
@@ -781,12 +840,12 @@ func (s *Server) handleUpdatePixel(c *gin.Context) {
 		req.URL = ""
 	}
 
-	updated, err := s.store.UpdatePixelForUser(c.Request.Context(), user.ID, sqlite.Pixel{
+	updated, updatedUser, err := s.store.UpdatePixelForUserWithCost(c.Request.Context(), user.ID, sqlite.Pixel{
 		ID:     req.ID,
 		Status: req.Status,
 		Color:  req.Color,
 		URL:    req.URL,
-	})
+	}, s.pixelCostPoints)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "pixel not found"})
@@ -796,12 +855,20 @@ func (s *Server) handleUpdatePixel(c *gin.Context) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "pixel already owned"})
 			return
 		}
+		if errors.Is(err, sqlite.ErrInsufficientPoints) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "brak wystarczającej liczby punktów. Aktywuj kod, aby zdobyć więcej."})
+			return
+		}
 		log.Printf("update pixel %d: %v", req.ID, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update pixel"})
 		return
 	}
 
-	c.JSON(http.StatusOK, updated)
+	c.JSON(http.StatusOK, gin.H{
+		"pixel":             updated,
+		"user":              sanitizeUser(updatedUser),
+		"pixel_cost_points": s.pixelCostPoints,
+	})
 }
 
 func seedDemoPixels(ctx context.Context, store *sqlite.Store) {

--- a/backend/main_login_test.go
+++ b/backend/main_login_test.go
@@ -28,6 +28,8 @@ func TestHandleLogin_UnverifiedResendsVerificationEmail(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
+	store.SetSkipPixelSeed(true)
+
 	if err := store.EnsureSchema(context.Background()); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
@@ -56,6 +58,7 @@ func TestHandleLogin_UnverifiedResendsVerificationEmail(t *testing.T) {
 		mailer:               mailer,
 		verificationBaseURL:  "http://example.com",
 		verificationTokenTTL: time.Hour,
+		pixelCostPoints:      10,
 	}
 
 	body := bytes.NewBufferString(`{"email":"user@example.com","password":"` + testLoginPassword + `"}`)
@@ -104,6 +107,8 @@ func TestHandleLogin_UnverifiedWhenVerificationDisabled(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
+	store.SetSkipPixelSeed(true)
+
 	if err := store.EnsureSchema(context.Background()); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
@@ -132,6 +137,7 @@ func TestHandleLogin_UnverifiedWhenVerificationDisabled(t *testing.T) {
 		verificationBaseURL:      "http://example.com",
 		verificationTokenTTL:     time.Hour,
 		disableVerificationEmail: true,
+		pixelCostPoints:          10,
 	}
 
 	body := bytes.NewBufferString(`{"email":"user@example.com","password":"` + testLoginPassword + `"}`)

--- a/backend/main_points_test.go
+++ b/backend/main_points_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gin "github.com/gin-gonic/gin"
+
+	"github.com/example/kup-piksel/internal/storage/sqlite"
+)
+
+type redeemResponse struct {
+	User struct {
+		Points int64 `json:"points"`
+	} `json:"user"`
+	AddedPoints int64 `json:"added_points"`
+}
+
+type updatePixelResponse struct {
+	User struct {
+		Points int64 `json:"points"`
+	} `json:"user"`
+	Pixel struct {
+		ID     int    `json:"id"`
+		Status string `json:"status"`
+	} `json:"pixel"`
+}
+
+func setupTestServer(t *testing.T) (*Server, *sqlite.Store) {
+	t.Helper()
+
+	store, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	store.SetSkipPixelSeed(true)
+
+	if err := store.EnsureSchema(context.Background()); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+
+	if err := store.InsertPixel(context.Background(), sqlite.Pixel{ID: 1, Status: "free"}); err != nil {
+		t.Fatalf("insert pixel: %v", err)
+	}
+
+	server := &Server{
+		store:                store,
+		sessions:             NewSessionManager(),
+		mailer:               &fakeMailer{},
+		verificationBaseURL:  "http://example.com",
+		verificationTokenTTL: time.Hour,
+		pixelCostPoints:      10,
+	}
+	return server, store
+}
+
+func TestHandleRedeemActivationCode_Success(t *testing.T) {
+	server, store := setupTestServer(t)
+
+	user, err := store.CreateUser(context.Background(), "user@example.com", "hash")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if err := store.CreateActivationCode(context.Background(), "ABCD-EFGH-IJKL-MNOP", 25); err != nil {
+		t.Fatalf("create activation code: %v", err)
+	}
+
+	sessionID, err := server.sessions.Create(user.ID)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"code":"ABCD-EFGH-IJKL-MNOP"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/activation-codes/redeem", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+	w := httptest.NewRecorder()
+	c := &gin.Context{Writer: w, Request: req}
+
+	server.handleRedeemActivationCode(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp redeemResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.AddedPoints != 25 {
+		t.Fatalf("expected added points 25, got %d", resp.AddedPoints)
+	}
+	if resp.User.Points != 25 {
+		t.Fatalf("expected user points 25, got %d", resp.User.Points)
+	}
+
+	refreshed, err := store.GetUserByID(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if refreshed.Points != 25 {
+		t.Fatalf("expected stored user points 25, got %d", refreshed.Points)
+	}
+}
+
+func TestHandleUpdatePixelRequiresPoints(t *testing.T) {
+	server, store := setupTestServer(t)
+
+	user, err := store.CreateUser(context.Background(), "user@example.com", "hash")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	sessionID, err := server.sessions.Create(user.ID)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Attempt to purchase without points.
+	purchaseBody := bytes.NewBufferString(`{"id":1,"status":"taken","color":"#ffffff","url":"https://example.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/pixels", purchaseBody)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+	w := httptest.NewRecorder()
+	c := &gin.Context{Writer: w, Request: req}
+
+	server.handleUpdatePixel(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403 for insufficient points, got %d", w.Code)
+	}
+	t.Log("insufficient points handled")
+
+	// Redeem activation code to gain points.
+	if err := store.CreateActivationCode(context.Background(), "WXYZ-1234-5678-90AB", 40); err != nil {
+		t.Fatalf("create activation code: %v", err)
+	}
+
+	redeemBody := bytes.NewBufferString(`{"code":"WXYZ-1234-5678-90AB"}`)
+	redeemReq := httptest.NewRequest(http.MethodPost, "/api/activation-codes/redeem", redeemBody)
+	redeemReq.Header.Set("Content-Type", "application/json")
+	redeemReq.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+	redeemW := httptest.NewRecorder()
+	redeemCtx := &gin.Context{Writer: redeemW, Request: redeemReq}
+	server.handleRedeemActivationCode(redeemCtx)
+	if redeemW.Code != http.StatusOK {
+		t.Fatalf("expected status 200 when redeeming code, got %d", redeemW.Code)
+	}
+	t.Log("activation code redeemed")
+
+	// Try to purchase again with points.
+	purchaseBody = bytes.NewBufferString(`{"id":1,"status":"taken","color":"#0000ff","url":"https://example.com"}`)
+	req = httptest.NewRequest(http.MethodPost, "/api/pixels", purchaseBody)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+	w = httptest.NewRecorder()
+	c = &gin.Context{Writer: w, Request: req}
+
+	server.handleUpdatePixel(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	t.Log("pixel purchase succeeded")
+
+	var resp updatePixelResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.Pixel.ID != 1 {
+		t.Fatalf("expected pixel id 1, got %d", resp.Pixel.ID)
+	}
+	if resp.Pixel.Status != "taken" {
+		t.Fatalf("expected pixel status taken, got %s", resp.Pixel.Status)
+	}
+	if resp.User.Points != 30 {
+		t.Fatalf("expected remaining points 30, got %d", resp.User.Points)
+	}
+}

--- a/backend/main_register_test.go
+++ b/backend/main_register_test.go
@@ -38,6 +38,8 @@ func TestHandleRegister_DisableVerificationEmail(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
+	store.SetSkipPixelSeed(true)
+
 	if err := store.EnsureSchema(context.Background()); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
@@ -50,6 +52,7 @@ func TestHandleRegister_DisableVerificationEmail(t *testing.T) {
 		verificationBaseURL:      "http://example.com",
 		verificationTokenTTL:     time.Hour,
 		disableVerificationEmail: true,
+		pixelCostPoints:          10,
 	}
 
 	body := bytes.NewBufferString(`{"email":"user@example.com","password":"strong"}`)
@@ -83,6 +86,8 @@ func TestHandleRegister_ExistingUnverifiedResendsEmail(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
+	store.SetSkipPixelSeed(true)
+
 	if err := store.EnsureSchema(context.Background()); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
@@ -99,6 +104,7 @@ func TestHandleRegister_ExistingUnverifiedResendsEmail(t *testing.T) {
 		mailer:               mailer,
 		verificationBaseURL:  "http://example.com",
 		verificationTokenTTL: time.Hour,
+		pixelCostPoints:      10,
 	}
 
 	body := bytes.NewBufferString(`{"email":"user@example.com","password":"strong"}`)
@@ -151,6 +157,8 @@ func TestHandleRegister_ExistingVerifiedConflict(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
+	store.SetSkipPixelSeed(true)
+
 	if err := store.EnsureSchema(context.Background()); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
@@ -170,6 +178,7 @@ func TestHandleRegister_ExistingVerifiedConflict(t *testing.T) {
 		mailer:               mailer,
 		verificationBaseURL:  "http://example.com",
 		verificationTokenTTL: time.Hour,
+		pixelCostPoints:      10,
 	}
 
 	body := bytes.NewBufferString(`{"email":"user@example.com","password":"strong"}`)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc --project tsconfig.test.json && node dist-tests/tests/activationCode.test.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/src/components/ActivationCodeModal.tsx
+++ b/frontend/src/components/ActivationCodeModal.tsx
@@ -1,0 +1,193 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useAuth } from "../useAuth";
+import { isActivationCodeValid, normalizeActivationCode } from "../utils/activationCode";
+
+type ActivationCodeModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: (addedPoints?: number) => void;
+};
+
+type RedeemResponse = {
+  added_points?: number;
+  error?: string;
+  user?: {
+    points?: number;
+  };
+  [key: string]: unknown;
+};
+
+export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: ActivationCodeModalProps) {
+  const { user, pixelCostPoints } = useAuth();
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetState = useCallback(() => {
+    setCode("");
+    setError(null);
+    setSuccessMessage(null);
+    setIsSubmitting(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetState();
+    }
+  }, [isOpen, resetState]);
+
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    resetState();
+    onClose();
+  }, [isSubmitting, onClose, resetState]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (isSubmitting) return;
+      setError(null);
+      setSuccessMessage(null);
+
+      const normalized = normalizeActivationCode(code);
+      if (!isActivationCodeValid(normalized)) {
+        setError("Kod musi mieć format XXXX-XXXX-XXXX-XXXX i składać się z cyfr lub liter.");
+        return;
+      }
+
+      setIsSubmitting(true);
+      try {
+        const response = await fetch("/api/activation-codes/redeem", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({ code: normalized }),
+        });
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            throw new Error("Twoja sesja wygasła. Zaloguj się ponownie i spróbuj jeszcze raz.");
+          }
+          const payload = (await response.json().catch(() => null)) as RedeemResponse | null;
+          const message =
+            payload && typeof payload.error === "string"
+              ? (payload.error as string)
+              : "Nie udało się aktywować kodu. Upewnij się, że nie został już użyty.";
+          throw new Error(message);
+        }
+
+        const payload = (await response.json().catch(() => null)) as RedeemResponse | null;
+        const addedPoints = payload && typeof payload.added_points === "number" ? payload.added_points : undefined;
+        const totalPoints =
+          payload && payload.user && typeof payload.user.points === "number" ? payload.user.points : undefined;
+
+        setCode("");
+        if (addedPoints && addedPoints > 0) {
+          setSuccessMessage(`Kod aktywowany! Dodano ${addedPoints} punktów${
+            typeof totalPoints === "number" ? ` (razem ${totalPoints} pkt).` : "."
+          }`);
+        } else {
+          setSuccessMessage("Kod został aktywowany.");
+        }
+        setError(null);
+        if (onSuccess) {
+          onSuccess(addedPoints);
+        }
+      } catch (err) {
+        console.error("redeem activation code", err);
+        const message = err instanceof Error ? err.message : "Nie udało się aktywować kodu.";
+        setError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [code, isSubmitting, onSuccess]
+  );
+
+  const infoText = useMemo(() => {
+    if (typeof pixelCostPoints === "number" && Number.isFinite(pixelCostPoints)) {
+      return `Koszt jednego piksela to ${pixelCostPoints} punktów.`;
+    }
+    return "Aktywuj kod, aby otrzymać punkty i kupować piksele.";
+  }, [pixelCostPoints]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 backdrop-blur">
+      <div className="w-full max-w-lg rounded-3xl bg-slate-950/95 p-8 shadow-2xl ring-1 ring-white/10" role="dialog" aria-modal="true">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-100">Aktywuj kod punktowy</h2>
+            <p className="mt-1 text-sm text-slate-400">{infoText}</p>
+            {typeof user?.points === "number" && (
+              <p className="mt-1 text-xs text-slate-400">Aktualne saldo: {user.points} pkt</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-full bg-slate-800/80 px-2 py-1 text-lg leading-none text-slate-300 transition hover:text-slate-100"
+            aria-label="Zamknij"
+          >
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <label className="block text-sm font-medium text-slate-200" htmlFor="activation-code">
+            Kod aktywacyjny
+            <input
+              id="activation-code"
+              type="text"
+              value={code}
+              onChange={(event) => {
+                setCode(event.target.value.toUpperCase());
+                setError(null);
+              }}
+              className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950/70 px-4 py-3 font-mono text-sm uppercase tracking-[0.3em] text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none"
+              placeholder="XXXX-XXXX-XXXX-XXXX"
+              maxLength={19}
+              disabled={isSubmitting}
+              autoFocus
+            />
+          </label>
+
+          {error && (
+            <p role="alert" className="text-sm text-rose-400">
+              {error}
+            </p>
+          )}
+          {successMessage && (
+            <p role="status" className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+              {successMessage}
+            </p>
+          )}
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
+              disabled={isSubmitting}
+            >
+              Zamknij
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-emerald-950 shadow-lg transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Aktywuję..." : "Aktywuj"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/utils/activationCode.ts
+++ b/frontend/src/utils/activationCode.ts
@@ -1,0 +1,13 @@
+const activationCodeRegex = /^[A-Za-z0-9]{4}(?:-[A-Za-z0-9]{4}){3}$/;
+
+export function normalizeActivationCode(input: string): string {
+  return input.trim().toUpperCase();
+}
+
+export function isActivationCodeValid(input: string): boolean {
+  return activationCodeRegex.test(normalizeActivationCode(input));
+}
+
+export function getActivationCodePattern(): RegExp {
+  return activationCodeRegex;
+}

--- a/frontend/tests/activationCode.test.ts
+++ b/frontend/tests/activationCode.test.ts
@@ -1,0 +1,51 @@
+// @ts-ignore - node type definitions are not available in this environment
+import assert from "node:assert/strict";
+import { getActivationCodePattern, isActivationCodeValid, normalizeActivationCode } from "../src/utils/activationCode.js";
+
+declare const process: { exitCode?: number };
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+test("normalizeActivationCode trims and uppercases input", () => {
+  const input = "  abcd-efgh-ijkl-mnop  ";
+  const expected = "ABCD-EFGH-IJKL-MNOP";
+  assert.equal(normalizeActivationCode(input), expected);
+});
+
+test("isActivationCodeValid accepts properly formatted codes", () => {
+  const validCodes = [
+    "ABCD-EFGH-IJKL-MNOP",
+    "1234-5678-9ABC-DEF0",
+    "zzzz-zzzz-zzzz-zzzz",
+  ];
+  for (const code of validCodes) {
+    assert.equal(isActivationCodeValid(code), true, `${code} should be valid`);
+  }
+});
+
+test("isActivationCodeValid rejects invalid codes", () => {
+  const invalidCodes = [
+    "abcd-efgh-ijkl", // too short
+    "abcd-efgh-ijkl-mnop-qrst", // too long
+    "abcd_efgh_ijkl_mnop", // wrong separator
+    "abc!-efgh-ijkl-mnop", // invalid character
+    "", // empty
+  ];
+  for (const code of invalidCodes) {
+    assert.equal(isActivationCodeValid(code), false, `${code} should be invalid`);
+  }
+});
+
+test("normalizeActivationCode output matches API pattern", () => {
+  const normalized = normalizeActivationCode("a1b2-c3d4-e5f6-g7h8");
+  assert.equal(getActivationCodePattern().test(normalized), true);
+});

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-tests",
+    "rootDir": ".",
+    "module": "nodenext",
+    "target": "es2019",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "noEmit": false,
+    "declaration": false,
+    "skipLibCheck": true
+  },
+  "include": ["tests/**/*.ts", "src/utils/**/*.ts"],
+  "exclude": ["dist", "dist-tests", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- ensure pixel purchases deduct points transactionally and cover redemption flows with new tests
- expose the configured pixel cost in API responses, add an activation code redemption endpoint, and update handlers
- surface point balances and activation code UI on the frontend with validation utilities and tests

## Testing
- go test ./...
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf56d04e088326a9864bf8e2af43c8