### PR TITLE
Add MySQL storage implementation and configurable backend selection

### DIFF
--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -3,6 +3,19 @@
   "pixelCostPoints": 10,
   // Set to true to automatically mark newly created accounts as verified and skip emails.
   "disableVerificationEmail": false,
+  "database": {
+    "driver": "sqlite",
+    // Optional override for sqlite database path; defaults to PIXEL_DB_PATH or data/pixels_new.db.
+    "sqlitePath": "",
+    "mysql": {
+      // Default DSN used when connecting to a database inside docker-compose.
+      "dsn": "kup_pixel:kup_pixel@tcp(db:3306)/kup_pixel?parseTime=true",
+      // Alternate DSN pointing to a database running on the Docker host.
+      "externalDsn": "kup_pixel:kup_pixel@tcp(host.docker.internal:3306)/kup_pixel?parseTime=true",
+      // Set to true to prefer externalDsn when running inside Docker.
+      "useExternal": false
+    }
+  },
   // Configure SMTP to deliver verification emails. Leave the object empty or remove it to use the console mailer.
   "smtp": {
     "host": "smtp.example.com",

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,14 +5,14 @@ go 1.21.0
 toolchain go1.24.1
 
 require (
-	github.com/gin-gonic/gin v0.0.0
-	github.com/mattn/go-sqlite3 v1.14.22
-	golang.org/x/crypto/bcrypt v0.0.0
+        github.com/gin-gonic/gin v0.0.0
+        github.com/go-sql-driver/mysql v1.9.3
+        github.com/mattn/go-sqlite3 v1.14.22
+        golang.org/x/crypto/bcrypt v0.0.0
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.3 // indirect
+        filippo.io/edwards25519 v1.1.0 // indirect
 )
 
 replace github.com/gin-gonic/gin => ./internal/ginlite

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -37,6 +37,12 @@ func TestLoad_DisableVerificationWithoutSMTP(t *testing.T) {
 	if cfg.SMTP != nil {
 		t.Fatalf("expected SMTP to be nil, got %#v", cfg.SMTP)
 	}
+	if cfg.Database == nil {
+		t.Fatal("expected database configuration")
+	}
+	if cfg.Database.Driver != "sqlite" {
+		t.Fatalf("expected sqlite driver, got %q", cfg.Database.Driver)
+	}
 }
 
 func TestLoad_WithValidSMTP(t *testing.T) {
@@ -69,6 +75,12 @@ func TestLoad_WithValidSMTP(t *testing.T) {
 	if *cfg.SMTP != *expected {
 		t.Fatalf("unexpected SMTP configuration: %#v", cfg.SMTP)
 	}
+	if cfg.Database == nil {
+		t.Fatal("expected database configuration")
+	}
+	if cfg.Database.Driver != "sqlite" {
+		t.Fatalf("expected sqlite driver by default, got %q", cfg.Database.Driver)
+	}
 }
 
 func TestLoad_InvalidSMTP(t *testing.T) {
@@ -88,6 +100,22 @@ func TestLoad_InvalidSMTP(t *testing.T) {
 func TestLoad_MissingPath(t *testing.T) {
 	if _, err := Load(" "); err == nil {
 		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestLoad_InvalidDatabaseDriver(t *testing.T) {
+	path := writeTempConfig(t, `{ "database": { "driver": "oracle" } }`)
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error for unsupported driver")
+	}
+}
+
+func TestLoad_MySQLRequiresDSN(t *testing.T) {
+	path := writeTempConfig(t, `{ "database": { "driver": "mysql" } }`)
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error when mysql dsn missing")
 	}
 }
 
@@ -118,5 +146,11 @@ func TestWriteFile_DefaultConfig(t *testing.T) {
 
 	if cfg.SMTP != nil {
 		t.Fatalf("expected SMTP to be nil, got %#v", cfg.SMTP)
+	}
+	if cfg.Database == nil {
+		t.Fatal("expected database configuration")
+	}
+	if cfg.Database.Driver != "sqlite" {
+		t.Fatalf("expected sqlite driver, got %q", cfg.Database.Driver)
 	}
 }

--- a/backend/internal/storage/mysql/migrations/001_init.sql
+++ b/backend/internal/storage/mysql/migrations/001_init.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS pixels (
+    id INT NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    color VARCHAR(16) NULL,
+    url TEXT NULL,
+    owner_id BIGINT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    INDEX idx_pixels_status (status),
+    INDEX idx_pixels_owner (owner_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    email VARCHAR(255) NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    verified_at TIMESTAMP NULL,
+    user_points BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_users_email (email)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS activation_codes (
+    code VARCHAR(64) NOT NULL,
+    value BIGINT NOT NULL,
+    PRIMARY KEY (code)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS verification_tokens (
+    token VARCHAR(128) NOT NULL,
+    user_id BIGINT NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (token),
+    CONSTRAINT fk_verification_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_verification_tokens_user (user_id)
+) ENGINE=InnoDB;

--- a/backend/internal/storage/mysql/store.go
+++ b/backend/internal/storage/mysql/store.go
@@ -1,0 +1,612 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/example/kup-piksel/internal/storage"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type (
+	Pixel             = storage.Pixel
+	User              = storage.User
+	VerificationToken = storage.VerificationToken
+	PixelState        = storage.PixelState
+)
+
+//go:embed migrations/*.sql
+var migrationFiles embed.FS
+
+type Store struct {
+	db            *sql.DB
+	skipPixelSeed bool
+}
+
+var _ storage.Store = (*Store)(nil)
+
+func Open(dsn string) (*Store, error) {
+	if strings.TrimSpace(dsn) == "" {
+		return nil, errors.New("mysql dsn must not be empty")
+	}
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open mysql connection: %w", err)
+	}
+
+	db.SetConnMaxIdleTime(2 * time.Minute)
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetMaxIdleConns(5)
+	db.SetMaxOpenConns(10)
+
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *Store) SetSkipPixelSeed(skip bool) {
+	if s != nil {
+		s.skipPixelSeed = skip
+	}
+}
+
+func (s *Store) InsertPixel(ctx context.Context, pixel Pixel) error {
+	if pixel.ID < 0 || pixel.ID >= storage.TotalPixels {
+		return fmt.Errorf("invalid pixel id: %d", pixel.ID)
+	}
+
+	status := "free"
+	if trimmed := strings.TrimSpace(pixel.Status); trimmed != "" {
+		status = trimmed
+	}
+
+	color := strings.TrimSpace(pixel.Color)
+	url := strings.TrimSpace(pixel.URL)
+	var owner any
+	if pixel.OwnerID != nil {
+		owner = *pixel.OwnerID
+	}
+
+	_, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO pixels (id, status, color, url, owner_id, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE id = id`,
+		pixel.ID,
+		status,
+		nullableString(color),
+		nullableString(url),
+		owner,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("insert pixel: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) EnsureSchema(ctx context.Context) (err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin ensure schema: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	statements, loadErr := readMigrationStatements()
+	if loadErr != nil {
+		err = fmt.Errorf("load migrations: %w", loadErr)
+		return err
+	}
+
+	for _, stmt := range statements {
+		if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
+			err = fmt.Errorf("ensure schema statement failed: %w", execErr)
+			return err
+		}
+	}
+
+	var count int
+	if err = tx.QueryRowContext(ctx, `SELECT COUNT(1) FROM pixels`).Scan(&count); err != nil {
+		err = fmt.Errorf("count pixels: %w", err)
+		return err
+	}
+
+	if count == 0 && !s.skipPixelSeed {
+		now := time.Now().UTC()
+		stmt, prepErr := tx.PrepareContext(ctx, `INSERT INTO pixels (id, status, color, url, owner_id, updated_at) VALUES (?, 'free', '', '', NULL, ?)`)
+		if prepErr != nil {
+			err = fmt.Errorf("prepare pixel seed: %w", prepErr)
+			return err
+		}
+		defer stmt.Close()
+
+		for i := 0; i < storage.TotalPixels; i++ {
+			if ctx.Err() != nil {
+				err = ctx.Err()
+				return err
+			}
+			if _, execErr := stmt.ExecContext(ctx, i, now); execErr != nil {
+				err = fmt.Errorf("seed pixel %d: %w", i, execErr)
+				return err
+			}
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		err = fmt.Errorf("commit ensure schema: %w", commitErr)
+		return err
+	}
+	return nil
+}
+
+func readMigrationStatements() ([]string, error) {
+	entries, err := fs.ReadDir(migrationFiles, "migrations")
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	var statements []string
+	for _, entry := range entries {
+		data, err := migrationFiles.ReadFile("migrations/" + entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, splitStatements(string(data))...)
+	}
+	return statements, nil
+}
+
+func splitStatements(input string) []string {
+	raw := strings.Split(input, ";")
+	statements := make([]string, 0, len(raw))
+	for _, stmt := range raw {
+		trimmed := strings.TrimSpace(stmt)
+		if trimmed != "" {
+			statements = append(statements, trimmed)
+		}
+	}
+	return statements
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func (s *Store) GetPixelsByOwner(ctx context.Context, ownerID int64) ([]Pixel, error) {
+	if ownerID <= 0 {
+		return nil, errors.New("invalid owner id")
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT id, status, COALESCE(color, ''), COALESCE(url, ''), owner_id, updated_at FROM pixels WHERE owner_id = ? ORDER BY updated_at DESC`, ownerID)
+	if err != nil {
+		return nil, fmt.Errorf("query pixels by owner: %w", err)
+	}
+	defer rows.Close()
+
+	pixels := make([]Pixel, 0)
+	for rows.Next() {
+		var pixel Pixel
+		var owner sql.NullInt64
+		var updated sql.NullTime
+		if err := rows.Scan(&pixel.ID, &pixel.Status, &pixel.Color, &pixel.URL, &owner, &updated); err != nil {
+			return nil, fmt.Errorf("scan pixel: %w", err)
+		}
+		if owner.Valid {
+			oid := owner.Int64
+			pixel.OwnerID = &oid
+		}
+		if updated.Valid {
+			pixel.UpdatedAt = updated.Time.UTC()
+		}
+		pixels = append(pixels, pixel)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pixels by owner: %w", err)
+	}
+
+	return pixels, nil
+}
+
+func (s *Store) GetAllPixels(ctx context.Context) (PixelState, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, status, COALESCE(color, ''), COALESCE(url, ''), owner_id, updated_at FROM pixels ORDER BY id`)
+	if err != nil {
+		return PixelState{}, fmt.Errorf("query pixels: %w", err)
+	}
+	defer rows.Close()
+
+	pixels := make([]Pixel, 0, storage.TotalPixels)
+	for rows.Next() {
+		var pixel Pixel
+		var owner sql.NullInt64
+		var updated sql.NullTime
+		if err := rows.Scan(&pixel.ID, &pixel.Status, &pixel.Color, &pixel.URL, &owner, &updated); err != nil {
+			return PixelState{}, fmt.Errorf("scan pixel: %w", err)
+		}
+		if owner.Valid {
+			oid := owner.Int64
+			pixel.OwnerID = &oid
+		}
+		if updated.Valid {
+			pixel.UpdatedAt = updated.Time.UTC()
+		}
+		pixels = append(pixels, pixel)
+	}
+
+	if err := rows.Err(); err != nil {
+		return PixelState{}, fmt.Errorf("iterate pixels: %w", err)
+	}
+
+	return PixelState{Width: storage.GridWidth, Height: storage.GridHeight, Pixels: pixels}, nil
+}
+
+func (s *Store) UpdatePixel(ctx context.Context, pixel Pixel) (Pixel, error) {
+	updated, _, err := s.UpdatePixelForUserWithCost(ctx, 0, pixel, 0)
+	if err != nil {
+		return Pixel{}, err
+	}
+	return updated, nil
+}
+
+func (s *Store) UpdatePixelForUserWithCost(ctx context.Context, userID int64, pixel Pixel, cost int64) (Pixel, User, error) {
+	if pixel.ID < 0 || pixel.ID >= storage.TotalPixels {
+		return Pixel{}, User{}, fmt.Errorf("invalid pixel id: %d", pixel.ID)
+	}
+	if cost < 0 {
+		return Pixel{}, User{}, errors.New("cost must not be negative")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Pixel{}, User{}, fmt.Errorf("begin update pixel for user: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var currentPoints int64
+	if userID > 0 {
+		if err = tx.QueryRowContext(ctx, `SELECT user_points FROM users WHERE id = ?`, userID).Scan(&currentPoints); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return Pixel{}, User{}, sql.ErrNoRows
+			}
+			return Pixel{}, User{}, fmt.Errorf("load user points: %w", err)
+		}
+	}
+
+	var currentOwner sql.NullInt64
+	if err = tx.QueryRowContext(ctx, `SELECT owner_id FROM pixels WHERE id = ?`, pixel.ID).Scan(&currentOwner); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Pixel{}, User{}, sql.ErrNoRows
+		}
+		return Pixel{}, User{}, fmt.Errorf("load pixel owner: %w", err)
+	}
+
+	updated := Pixel{ID: pixel.ID}
+	chargeCost := false
+
+	if strings.EqualFold(pixel.Status, "taken") {
+		if pixel.Color == "" || pixel.URL == "" {
+			return Pixel{}, User{}, errors.New("taken pixels require color and url")
+		}
+		if currentOwner.Valid && userID > 0 && currentOwner.Int64 != userID {
+			return Pixel{}, User{}, storage.ErrPixelOwnedByAnotherUser
+		}
+		if (!currentOwner.Valid && cost > 0) || (currentOwner.Valid && userID > 0 && currentOwner.Int64 != userID) {
+			chargeCost = cost > 0
+		}
+		updated.Status = "taken"
+		updated.Color = pixel.Color
+		updated.URL = pixel.URL
+		if userID > 0 {
+			owner := userID
+			updated.OwnerID = &owner
+		}
+	} else {
+		if currentOwner.Valid && userID > 0 && currentOwner.Int64 != userID {
+			return Pixel{}, User{}, storage.ErrPixelOwnedByAnotherUser
+		}
+		updated.Status = "free"
+		updated.Color = ""
+		updated.URL = ""
+		updated.OwnerID = nil
+	}
+
+	if chargeCost {
+		if currentPoints < cost {
+			return Pixel{}, User{}, storage.ErrInsufficientPoints
+		}
+		res, execErr := tx.ExecContext(ctx, `UPDATE users SET user_points = user_points - ? WHERE id = ? AND user_points >= ?`, cost, userID, cost)
+		if execErr != nil {
+			return Pixel{}, User{}, fmt.Errorf("deduct user points: %w", execErr)
+		}
+		affected, affErr := res.RowsAffected()
+		if affErr != nil {
+			return Pixel{}, User{}, fmt.Errorf("deduct user points rows affected: %w", affErr)
+		}
+		if affected == 0 {
+			return Pixel{}, User{}, storage.ErrInsufficientPoints
+		}
+		currentPoints -= cost
+	}
+
+	updated.UpdatedAt = time.Now().UTC()
+	var owner any
+	if updated.OwnerID != nil {
+		owner = *updated.OwnerID
+	}
+
+	res, execErr := tx.ExecContext(
+		ctx,
+		`UPDATE pixels SET status = ?, color = ?, url = ?, owner_id = ?, updated_at = ? WHERE id = ?`,
+		updated.Status,
+		updated.Color,
+		updated.URL,
+		owner,
+		updated.UpdatedAt,
+		updated.ID,
+	)
+	if execErr != nil {
+		return Pixel{}, User{}, fmt.Errorf("update pixel: %w", execErr)
+	}
+	affected, affErr := res.RowsAffected()
+	if affErr != nil {
+		return Pixel{}, User{}, fmt.Errorf("update pixel rows affected: %w", affErr)
+	}
+	if affected == 0 {
+		return Pixel{}, User{}, sql.ErrNoRows
+	}
+
+	var updatedUser User
+	if userID > 0 {
+		row := tx.QueryRowContext(ctx, `SELECT id, email, password_hash, created_at, is_verified, verified_at, user_points FROM users WHERE id = ?`, userID)
+		updatedUser, err = scanUser(row)
+		if err != nil {
+			return Pixel{}, User{}, err
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return Pixel{}, User{}, fmt.Errorf("commit update pixel for user: %w", commitErr)
+	}
+
+	return updated, updatedUser, nil
+}
+
+func (s *Store) UpdatePixelForUser(ctx context.Context, userID int64, pixel Pixel) (Pixel, error) {
+	updated, _, err := s.UpdatePixelForUserWithCost(ctx, userID, pixel, 0)
+	return updated, err
+}
+
+func (s *Store) CreateUser(ctx context.Context, email, passwordHash string) (User, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return User{}, errors.New("email must not be empty")
+	}
+	if passwordHash == "" {
+		return User{}, errors.New("password hash must not be empty")
+	}
+
+	now := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `INSERT INTO users (email, password_hash, created_at, is_verified) VALUES (?, ?, ?, FALSE)`, email, passwordHash, now)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			return User{}, fmt.Errorf("email already exists: %w", err)
+		}
+		return User{}, fmt.Errorf("insert user: %w", err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return User{}, fmt.Errorf("last insert id: %w", err)
+	}
+
+	return User{ID: id, Email: email, PasswordHash: passwordHash, CreatedAt: now, IsVerified: false, Points: 0}, nil
+}
+
+func (s *Store) GetUserByEmail(ctx context.Context, email string) (User, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return User{}, errors.New("email must not be empty")
+	}
+
+	row := s.db.QueryRowContext(ctx, `SELECT id, email, password_hash, created_at, is_verified, verified_at, user_points FROM users WHERE email = ?`, email)
+	return scanUser(row)
+}
+
+func (s *Store) GetUserByID(ctx context.Context, id int64) (User, error) {
+	if id <= 0 {
+		return User{}, errors.New("invalid user id")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, email, password_hash, created_at, is_verified, verified_at, user_points FROM users WHERE id = ?`, id)
+	return scanUser(row)
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanUser(row rowScanner) (User, error) {
+	var user User
+	var created time.Time
+	var verified sql.NullTime
+	if err := row.Scan(&user.ID, &user.Email, &user.PasswordHash, &created, &user.IsVerified, &verified, &user.Points); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, sql.ErrNoRows
+		}
+		return User{}, fmt.Errorf("scan user: %w", err)
+	}
+	user.CreatedAt = created.UTC()
+	if verified.Valid {
+		t := verified.Time.UTC()
+		user.VerifiedAt = &t
+	}
+	return user, nil
+}
+
+func (s *Store) CreateActivationCode(ctx context.Context, code string, value int64) error {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return errors.New("activation code must not be empty")
+	}
+	if value <= 0 {
+		return errors.New("activation code value must be positive")
+	}
+
+	_, err := s.db.ExecContext(ctx, `INSERT INTO activation_codes (code, value) VALUES (?, ?)`, strings.ToUpper(code), value)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			return fmt.Errorf("activation code already exists: %w", err)
+		}
+		return fmt.Errorf("insert activation code: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) RedeemActivationCode(ctx context.Context, userID int64, code string) (User, int64, error) {
+	if userID <= 0 {
+		return User{}, 0, errors.New("invalid user id")
+	}
+	normalized := strings.ToUpper(strings.TrimSpace(code))
+	if normalized == "" {
+		return User{}, 0, errors.New("activation code must not be empty")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return User{}, 0, fmt.Errorf("begin redeem activation code: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var value int64
+	if err = tx.QueryRowContext(ctx, `SELECT value FROM activation_codes WHERE code = ?`, normalized).Scan(&value); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, 0, sql.ErrNoRows
+		}
+		return User{}, 0, fmt.Errorf("load activation code: %w", err)
+	}
+
+	if _, err = tx.ExecContext(ctx, `DELETE FROM activation_codes WHERE code = ?`, normalized); err != nil {
+		return User{}, 0, fmt.Errorf("delete activation code: %w", err)
+	}
+
+	if _, err = tx.ExecContext(ctx, `UPDATE users SET user_points = user_points + ? WHERE id = ?`, value, userID); err != nil {
+		return User{}, 0, fmt.Errorf("add user points: %w", err)
+	}
+
+	row := tx.QueryRowContext(ctx, `SELECT id, email, password_hash, created_at, is_verified, verified_at, user_points FROM users WHERE id = ?`, userID)
+	user, scanErr := scanUser(row)
+	if scanErr != nil {
+		return User{}, 0, scanErr
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return User{}, 0, fmt.Errorf("commit redeem activation code: %w", commitErr)
+	}
+
+	return user, value, nil
+}
+
+func (s *Store) CreateVerificationToken(ctx context.Context, token string, userID int64, expiresAt time.Time) (VerificationToken, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return VerificationToken{}, errors.New("token must not be empty")
+	}
+	if userID <= 0 {
+		return VerificationToken{}, errors.New("invalid user id")
+	}
+
+	now := time.Now().UTC()
+	_, err := s.db.ExecContext(ctx, `INSERT INTO verification_tokens (token, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)`, token, userID, expiresAt.UTC(), now)
+	if err != nil {
+		return VerificationToken{}, fmt.Errorf("insert verification token: %w", err)
+	}
+
+	return VerificationToken{Token: token, UserID: userID, ExpiresAt: expiresAt.UTC(), CreatedAt: now}, nil
+}
+
+func (s *Store) GetVerificationToken(ctx context.Context, token string) (VerificationToken, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return VerificationToken{}, errors.New("token must not be empty")
+	}
+
+	var record VerificationToken
+	if err := s.db.QueryRowContext(ctx, `SELECT token, user_id, expires_at, created_at FROM verification_tokens WHERE token = ?`, token).
+		Scan(&record.Token, &record.UserID, &record.ExpiresAt, &record.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return VerificationToken{}, sql.ErrNoRows
+		}
+		return VerificationToken{}, fmt.Errorf("get verification token: %w", err)
+	}
+	record.ExpiresAt = record.ExpiresAt.UTC()
+	record.CreatedAt = record.CreatedAt.UTC()
+	return record, nil
+}
+
+func (s *Store) DeleteVerificationToken(ctx context.Context, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return errors.New("token must not be empty")
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM verification_tokens WHERE token = ?`, token); err != nil {
+		return fmt.Errorf("delete verification token: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) DeleteVerificationTokensForUser(ctx context.Context, userID int64) error {
+	if userID <= 0 {
+		return errors.New("invalid user id")
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM verification_tokens WHERE user_id = ?`, userID); err != nil {
+		return fmt.Errorf("delete verification tokens for user: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) MarkUserVerified(ctx context.Context, userID int64) error {
+	if userID <= 0 {
+		return errors.New("invalid user id")
+	}
+	now := time.Now().UTC()
+	res, err := s.db.ExecContext(ctx, `UPDATE users SET is_verified = TRUE, verified_at = ? WHERE id = ?`, now, userID)
+	if err != nil {
+		return fmt.Errorf("mark user verified: %w", err)
+	}
+	affected, affErr := res.RowsAffected()
+	if affErr != nil {
+		return fmt.Errorf("mark user verified rows affected: %w", affErr)
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const (
+	GridWidth   = 1000
+	GridHeight  = 1000
+	TotalPixels = GridWidth * GridHeight
+)
+
+type Pixel struct {
+	ID        int       `json:"id"`
+	Status    string    `json:"status"`
+	Color     string    `json:"color,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	OwnerID   *int64    `json:"owner_id,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+type User struct {
+	ID           int64      `json:"id"`
+	Email        string     `json:"email"`
+	PasswordHash string     `json:"-"`
+	CreatedAt    time.Time  `json:"created_at"`
+	IsVerified   bool       `json:"is_verified"`
+	VerifiedAt   *time.Time `json:"verified_at,omitempty"`
+	Points       int64      `json:"points"`
+}
+
+type VerificationToken struct {
+	Token     string    `json:"token"`
+	UserID    int64     `json:"user_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type PixelState struct {
+	Width  int     `json:"width"`
+	Height int     `json:"height"`
+	Pixels []Pixel `json:"pixels"`
+}
+
+var (
+	ErrPixelOwnedByAnotherUser = errors.New("pixel owned by another user")
+	ErrInsufficientPoints      = errors.New("insufficient points")
+)
+
+type Store interface {
+	Close() error
+	EnsureSchema(ctx context.Context) error
+	SetSkipPixelSeed(skip bool)
+	InsertPixel(ctx context.Context, pixel Pixel) error
+	GetAllPixels(ctx context.Context) (PixelState, error)
+	UpdatePixel(ctx context.Context, pixel Pixel) (Pixel, error)
+	UpdatePixelForUserWithCost(ctx context.Context, userID int64, pixel Pixel, cost int64) (Pixel, User, error)
+	UpdatePixelForUser(ctx context.Context, userID int64, pixel Pixel) (Pixel, error)
+	GetPixelsByOwner(ctx context.Context, ownerID int64) ([]Pixel, error)
+	CreateUser(ctx context.Context, email, passwordHash string) (User, error)
+	GetUserByEmail(ctx context.Context, email string) (User, error)
+	GetUserByID(ctx context.Context, id int64) (User, error)
+	CreateActivationCode(ctx context.Context, code string, value int64) error
+	RedeemActivationCode(ctx context.Context, userID int64, code string) (User, int64, error)
+	CreateVerificationToken(ctx context.Context, token string, userID int64, expiresAt time.Time) (VerificationToken, error)
+	GetVerificationToken(ctx context.Context, token string) (VerificationToken, error)
+	DeleteVerificationToken(ctx context.Context, token string) error
+	DeleteVerificationTokensForUser(ctx context.Context, userID int64) error
+	MarkUserVerified(ctx context.Context, userID int64) error
+}

--- a/backend/main_points_test.go
+++ b/backend/main_points_test.go
@@ -6,11 +6,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	gin "github.com/gin-gonic/gin"
 
+	"github.com/example/kup-piksel/internal/storage"
+	"github.com/example/kup-piksel/internal/storage/mysql"
 	"github.com/example/kup-piksel/internal/storage/sqlite"
 )
 
@@ -31,26 +35,67 @@ type updatePixelResponse struct {
 	} `json:"pixel"`
 }
 
-func setupTestServer(t *testing.T) (*Server, *sqlite.Store) {
+type storeFactory struct {
+	name string
+	new  func(t *testing.T) storage.Store
+}
+
+func runStoreTests(t *testing.T, test func(t *testing.T, server *Server, store storage.Store)) {
 	t.Helper()
 
-	store, err := sqlite.Open(":memory:")
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
+	factories := []storeFactory{
+		{
+			name: "sqlite",
+			new: func(t *testing.T) storage.Store {
+				store, err := sqlite.Open(":memory:")
+				if err != nil {
+					t.Fatalf("open sqlite: %v", err)
+				}
+				t.Cleanup(func() { _ = store.Close() })
+				prepareStore(t, store)
+				return store
+			},
+		},
+		{
+			name: "mysql",
+			new: func(t *testing.T) storage.Store {
+				dsn := mysqlContainerDSN(t)
+				store, err := mysql.Open(dsn)
+				if err != nil {
+					t.Fatalf("open mysql: %v", err)
+				}
+				t.Cleanup(func() { _ = store.Close() })
+				prepareStore(t, store)
+				return store
+			},
+		},
 	}
-	t.Cleanup(func() { _ = store.Close() })
+
+	for _, factory := range factories {
+		factory := factory
+		t.Run(factory.name, func(t *testing.T) {
+			store := factory.new(t)
+			server := newTestServer(t, store)
+			test(t, server, store)
+		})
+	}
+}
+
+func prepareStore(t *testing.T, store storage.Store) {
+	t.Helper()
 
 	store.SetSkipPixelSeed(true)
-
 	if err := store.EnsureSchema(context.Background()); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
-
-	if err := store.InsertPixel(context.Background(), sqlite.Pixel{ID: 1, Status: "free"}); err != nil {
+	if err := store.InsertPixel(context.Background(), storage.Pixel{ID: 1, Status: "free"}); err != nil {
 		t.Fatalf("insert pixel: %v", err)
 	}
+}
 
-	server := &Server{
+func newTestServer(t *testing.T, store storage.Store) *Server {
+	t.Helper()
+	return &Server{
 		store:                store,
 		sessions:             NewSessionManager(),
 		mailer:               &fakeMailer{},
@@ -58,132 +103,139 @@ func setupTestServer(t *testing.T) (*Server, *sqlite.Store) {
 		verificationTokenTTL: time.Hour,
 		pixelCostPoints:      10,
 	}
-	return server, store
+}
+
+func mysqlContainerDSN(t *testing.T) string {
+	t.Helper()
+
+	if dsn := os.Getenv("MYSQL_TEST_DSN"); strings.TrimSpace(dsn) != "" {
+		return dsn
+	}
+
+	t.Skip("MYSQL_TEST_DSN not provided; skipping MariaDB integration tests")
+	return ""
 }
 
 func TestHandleRedeemActivationCode_Success(t *testing.T) {
-	server, store := setupTestServer(t)
+	runStoreTests(t, func(t *testing.T, server *Server, store storage.Store) {
+		user, err := store.CreateUser(context.Background(), "user@example.com", "hash")
+		if err != nil {
+			t.Fatalf("create user: %v", err)
+		}
 
-	user, err := store.CreateUser(context.Background(), "user@example.com", "hash")
-	if err != nil {
-		t.Fatalf("create user: %v", err)
-	}
+		if err := store.CreateActivationCode(context.Background(), "ABCD-EFGH-IJKL-MNOP", 25); err != nil {
+			t.Fatalf("create activation code: %v", err)
+		}
 
-	if err := store.CreateActivationCode(context.Background(), "ABCD-EFGH-IJKL-MNOP", 25); err != nil {
-		t.Fatalf("create activation code: %v", err)
-	}
+		sessionID, err := server.sessions.Create(user.ID)
+		if err != nil {
+			t.Fatalf("create session: %v", err)
+		}
 
-	sessionID, err := server.sessions.Create(user.ID)
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
+		body := bytes.NewBufferString(`{"code":"ABCD-EFGH-IJKL-MNOP"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/activation-codes/redeem", body)
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+		w := httptest.NewRecorder()
+		c := &gin.Context{Writer: w, Request: req}
 
-	body := bytes.NewBufferString(`{"code":"ABCD-EFGH-IJKL-MNOP"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/activation-codes/redeem", body)
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
-	w := httptest.NewRecorder()
-	c := &gin.Context{Writer: w, Request: req}
+		server.handleRedeemActivationCode(c)
 
-	server.handleRedeemActivationCode(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", w.Code)
-	}
+		var resp redeemResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
 
-	var resp redeemResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
+		if resp.AddedPoints != 25 {
+			t.Fatalf("expected added points 25, got %d", resp.AddedPoints)
+		}
+		if resp.User.Points != 25 {
+			t.Fatalf("expected user points 25, got %d", resp.User.Points)
+		}
 
-	if resp.AddedPoints != 25 {
-		t.Fatalf("expected added points 25, got %d", resp.AddedPoints)
-	}
-	if resp.User.Points != 25 {
-		t.Fatalf("expected user points 25, got %d", resp.User.Points)
-	}
-
-	refreshed, err := store.GetUserByID(context.Background(), user.ID)
-	if err != nil {
-		t.Fatalf("get user: %v", err)
-	}
-	if refreshed.Points != 25 {
-		t.Fatalf("expected stored user points 25, got %d", refreshed.Points)
-	}
+		refreshed, err := store.GetUserByID(context.Background(), user.ID)
+		if err != nil {
+			t.Fatalf("get user: %v", err)
+		}
+		if refreshed.Points != 25 {
+			t.Fatalf("expected stored user points 25, got %d", refreshed.Points)
+		}
+	})
 }
 
 func TestHandleUpdatePixelRequiresPoints(t *testing.T) {
-	server, store := setupTestServer(t)
+	runStoreTests(t, func(t *testing.T, server *Server, store storage.Store) {
+		user, err := store.CreateUser(context.Background(), "user@example.com", "hash")
+		if err != nil {
+			t.Fatalf("create user: %v", err)
+		}
 
-	user, err := store.CreateUser(context.Background(), "user@example.com", "hash")
-	if err != nil {
-		t.Fatalf("create user: %v", err)
-	}
+		sessionID, err := server.sessions.Create(user.ID)
+		if err != nil {
+			t.Fatalf("create session: %v", err)
+		}
 
-	sessionID, err := server.sessions.Create(user.ID)
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
+		purchaseBody := bytes.NewBufferString(`{"id":1,"status":"taken","color":"#ffffff","url":"https://example.com"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/pixels", purchaseBody)
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+		w := httptest.NewRecorder()
+		c := &gin.Context{Writer: w, Request: req}
 
-	// Attempt to purchase without points.
-	purchaseBody := bytes.NewBufferString(`{"id":1,"status":"taken","color":"#ffffff","url":"https://example.com"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/pixels", purchaseBody)
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
-	w := httptest.NewRecorder()
-	c := &gin.Context{Writer: w, Request: req}
+		server.handleUpdatePixel(c)
 
-	server.handleUpdatePixel(c)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected status 403 for insufficient points, got %d", w.Code)
+		}
+		t.Log("insufficient points handled")
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected status 403 for insufficient points, got %d", w.Code)
-	}
-	t.Log("insufficient points handled")
+		if err := store.CreateActivationCode(context.Background(), "WXYZ-1234-5678-90AB", 40); err != nil {
+			t.Fatalf("create activation code: %v", err)
+		}
 
-	// Redeem activation code to gain points.
-	if err := store.CreateActivationCode(context.Background(), "WXYZ-1234-5678-90AB", 40); err != nil {
-		t.Fatalf("create activation code: %v", err)
-	}
+		redeemBody := bytes.NewBufferString(`{"code":"WXYZ-1234-5678-90AB"}`)
+		redeemReq := httptest.NewRequest(http.MethodPost, "/api/activation-codes/redeem", redeemBody)
+		redeemReq.Header.Set("Content-Type", "application/json")
+		redeemReq.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+		redeemW := httptest.NewRecorder()
+		redeemCtx := &gin.Context{Writer: redeemW, Request: redeemReq}
+		server.handleRedeemActivationCode(redeemCtx)
+		if redeemW.Code != http.StatusOK {
+			t.Fatalf("expected status 200 when redeeming code, got %d", redeemW.Code)
+		}
+		t.Log("activation code redeemed")
 
-	redeemBody := bytes.NewBufferString(`{"code":"WXYZ-1234-5678-90AB"}`)
-	redeemReq := httptest.NewRequest(http.MethodPost, "/api/activation-codes/redeem", redeemBody)
-	redeemReq.Header.Set("Content-Type", "application/json")
-	redeemReq.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
-	redeemW := httptest.NewRecorder()
-	redeemCtx := &gin.Context{Writer: redeemW, Request: redeemReq}
-	server.handleRedeemActivationCode(redeemCtx)
-	if redeemW.Code != http.StatusOK {
-		t.Fatalf("expected status 200 when redeeming code, got %d", redeemW.Code)
-	}
-	t.Log("activation code redeemed")
+		purchaseBody = bytes.NewBufferString(`{"id":1,"status":"taken","color":"#0000ff","url":"https://example.com"}`)
+		req = httptest.NewRequest(http.MethodPost, "/api/pixels", purchaseBody)
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+		w = httptest.NewRecorder()
+		c = &gin.Context{Writer: w, Request: req}
 
-	// Try to purchase again with points.
-	purchaseBody = bytes.NewBufferString(`{"id":1,"status":"taken","color":"#0000ff","url":"https://example.com"}`)
-	req = httptest.NewRequest(http.MethodPost, "/api/pixels", purchaseBody)
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
-	w = httptest.NewRecorder()
-	c = &gin.Context{Writer: w, Request: req}
+		server.handleUpdatePixel(c)
 
-	server.handleUpdatePixel(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+		t.Log("pixel purchase succeeded")
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", w.Code)
-	}
-	t.Log("pixel purchase succeeded")
+		var resp updatePixelResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
 
-	var resp updatePixelResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
-
-	if resp.Pixel.ID != 1 {
-		t.Fatalf("expected pixel id 1, got %d", resp.Pixel.ID)
-	}
-	if resp.Pixel.Status != "taken" {
-		t.Fatalf("expected pixel status taken, got %s", resp.Pixel.Status)
-	}
-	if resp.User.Points != 30 {
-		t.Fatalf("expected remaining points 30, got %d", resp.User.Points)
-	}
+		if resp.Pixel.ID != 1 {
+			t.Fatalf("expected pixel id 1, got %d", resp.Pixel.ID)
+		}
+		if resp.Pixel.Status != "taken" {
+			t.Fatalf("expected pixel status taken, got %s", resp.Pixel.Status)
+		}
+		if resp.User.Points != 30 {
+			t.Fatalf("expected remaining points 30, got %d", resp.User.Points)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- add a shared storage interface and refactor the sqlite store to implement it
- introduce a MySQL-backed storage package with migrations and database configuration options
- update the server startup flow and tests to support selecting between sqlite and MySQL implementations

## Testing
- `go test ./...` *(fails: unable to download github.com/go-sql-driver/mysql in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07e3085ac83268bf5096edf33c6c5