### PR TITLE
Use real MySQL driver during normal builds

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -17,8 +17,6 @@ require (
 
 replace github.com/gin-gonic/gin => ./internal/ginlite
 
-replace github.com/go-sql-driver/mysql => ./internal/mysqlstub
-
 replace github.com/mattn/go-sqlite3 => ./internal/sqlite3
 
 replace golang.org/x/crypto/bcrypt => ./internal/bcrypt

--- a/backend/internal/mysqlstub/mysql.go
+++ b/backend/internal/mysqlstub/mysql.go
@@ -1,3 +1,6 @@
+//go:build test
+// +build test
+
 package mysql
 
 import (


### PR DESCRIPTION
## Summary
- remove the module replacement that forced the backend to build against the local MySQL stub
- scope the stubbed driver to a dedicated `test` build tag so it can still be enabled explicitly for tagged test runs

## Testing
- `go test ./...` *(fails: unable to download github.com/go-sql-driver/mysql because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d092e3f2e8832683174eeaacf414c3