### PR TITLE
Add terms page and enforce terms acceptance

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { type ChangeEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { Link, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import PixelCanvas, { Pixel } from "./components/PixelCanvas";
 import LoginModal from "./components/LoginModal";
@@ -6,6 +6,8 @@ import RegisterModal from "./components/RegisterModal";
 import VerifyAccountPage from "./components/VerifyAccountPage";
 import AccountPage from "./components/AccountPage";
 import ActivationCodeModal from "./components/ActivationCodeModal";
+import TermsFooter from "./components/TermsFooter";
+import TermsPage from "./components/TermsPage";
 import { useAuth } from "./useAuth";
 
 type PixelResponse = {
@@ -626,6 +628,15 @@ function BuyPixelPage() {
   );
 }
 
+function PageLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <main className="flex-1">{children}</main>
+      <TermsFooter />
+    </div>
+  );
+}
+
 export default function App() {
   const { openLoginModal, refresh } = useAuth();
   const [isRegisterOpen, setIsRegisterOpen] = useState(false);
@@ -664,21 +675,49 @@ export default function App() {
       <Routes>
         <Route
           path="/"
-          element={<LandingPage onOpenRegister={handleOpenRegister} onOpenActivationCode={handleOpenActivationCode} />}
+          element={
+            <PageLayout>
+              <LandingPage onOpenRegister={handleOpenRegister} onOpenActivationCode={handleOpenActivationCode} />
+            </PageLayout>
+          }
         />
         <Route path="/account" element={<AccountPage onOpenActivationCode={handleOpenActivationCode} />} />
         <Route path="/verify" element={<VerifyAccountPage />} />
-        <Route path="/buy" element={<BuyPixelPage />} />
-        <Route path="/buy/:pixelId" element={<BuyPixelPage />} />
+        <Route
+          path="/buy"
+          element={
+            <PageLayout>
+              <BuyPixelPage />
+            </PageLayout>
+          }
+        />
+        <Route
+          path="/buy/:pixelId"
+          element={
+            <PageLayout>
+              <BuyPixelPage />
+            </PageLayout>
+          }
+        />
+        <Route
+          path="/terms"
+          element={
+            <PageLayout>
+              <TermsPage />
+            </PageLayout>
+          }
+        />
         <Route
           path="*"
           element={
-            <div className="flex min-h-screen flex-col items-center justify-center gap-3 text-center text-slate-300">
-              <h2 className="text-2xl font-semibold text-white">Ups! Nie znaleziono strony.</h2>
-              <Link to="/" className="text-blue-400 underline">
-                Wróć na tablicę pikseli
-              </Link>
-            </div>
+            <PageLayout>
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-slate-300">
+                <h2 className="text-2xl font-semibold text-white">Ups! Nie znaleziono strony.</h2>
+                <Link to="/" className="text-blue-400 underline">
+                  Wróć na tablicę pikseli
+                </Link>
+              </div>
+            </PageLayout>
           }
         />
       </Routes>

--- a/frontend/src/components/AccountPage.tsx
+++ b/frontend/src/components/AccountPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth, type AuthUser } from "../useAuth";
+import TermsFooter from "./TermsFooter";
 
 type AccountPixel = {
   id: number;
@@ -296,8 +297,9 @@ export default function AccountPage({ onOpenActivationCode }: AccountPageProps =
   }, [editValue, editingId, navigate, openLoginModal, pixels]);
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-200">
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-12">
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-200">
+      <main className="flex-1">
+        <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-12">
         <header className="space-y-2 text-center">
           <h1 className="text-3xl font-semibold text-blue-400">Twoje konto</h1>
           <p className="text-sm text-slate-400">Zarządzaj zakupionymi pikselami i aktualizuj adresy reklam.</p>
@@ -473,7 +475,9 @@ export default function AccountPage({ onOpenActivationCode }: AccountPageProps =
             </div>
           )}
         </div>
-      </div>
+        </div>
+      </main>
+      <TermsFooter />
     </div>
   );
 }

--- a/frontend/src/components/RegisterModal.tsx
+++ b/frontend/src/components/RegisterModal.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useCallback, useState } from "react";
+import { Link } from "react-router-dom";
 import { useAuth } from "../useAuth";
 import ResendVerificationForm from "./ResendVerificationForm";
 
@@ -12,6 +13,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
   const { register } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -20,6 +22,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
   const resetState = useCallback(() => {
     setEmail("");
     setPassword("");
+    setAcceptedTerms(false);
     setError(null);
     setIsSubmitting(false);
     setIsSuccess(false);
@@ -36,6 +39,10 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       setError(null);
+      if (!acceptedTerms) {
+        setError("Aby utworzyć konto, zaakceptuj regulamin.");
+        return;
+      }
       setIsSubmitting(true);
       try {
         const result = await register({ email, password });
@@ -50,7 +57,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
         setIsSubmitting(false);
       }
     },
-    [email, password, register, resetState, onClose]
+    [acceptedTerms, email, password, register]
   );
 
   if (!isOpen) {
@@ -146,6 +153,28 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
               />
             </label>
 
+            <label className="flex items-start gap-3 text-xs text-slate-300">
+              <input
+                type="checkbox"
+                checked={acceptedTerms}
+                onChange={(event) => {
+                  setAcceptedTerms(event.target.checked);
+                  if (event.target.checked) {
+                    setError(null);
+                  }
+                }}
+                disabled={isSubmitting}
+                className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-900 text-blue-500 focus:ring-blue-400"
+              />
+              <span>
+                Akceptuję {" "}
+                <Link to="/terms" className="font-semibold text-blue-300 underline-offset-2 hover:underline">
+                  Regulamin
+                </Link>{" "}
+                serwisu.
+              </span>
+            </label>
+
             {error && (
               <p role="alert" className="text-sm text-rose-400">
                 {error}
@@ -179,7 +208,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
                 <button
                   type="submit"
                   className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || !acceptedTerms}
                 >
                   {isSubmitting ? "Tworzenie..." : "Zarejestruj się"}
                 </button>

--- a/frontend/src/components/TermsFooter.tsx
+++ b/frontend/src/components/TermsFooter.tsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+export default function TermsFooter() {
+  return (
+    <footer className="mt-auto bg-slate-900/80 py-4 text-center text-xs text-slate-400">
+      <div className="container mx-auto flex flex-col items-center justify-center gap-1 px-4 sm:flex-row">
+        <span>Korzystanie z serwisu oznacza akceptację regulaminu.</span>
+        <Link
+          to="/terms"
+          className="font-semibold text-blue-300 transition hover:text-blue-200"
+        >
+          Przeczytaj regulamin
+        </Link>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/TermsPage.tsx
+++ b/frontend/src/components/TermsPage.tsx
@@ -1,0 +1,176 @@
+export default function TermsPage() {
+  return (
+    <div className="bg-slate-950 text-slate-100">
+      <div className="mx-auto max-w-4xl px-6 py-12">
+        <header className="mb-10">
+          <h1 className="text-4xl font-bold text-blue-300">Regulamin serwisu KupPixel</h1>
+          <p className="mt-4 text-sm text-slate-300">
+            Niniejszy regulamin określa zasady korzystania z serwisu KupPixel, w tym warunki
+            świadczenia usług drogą elektroniczną, zasady odpowiedzialności oraz tryb składania
+            reklamacji. Korzystając z serwisu, akceptujesz postanowienia poniższego dokumentu.
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">1. Postanowienia ogólne</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              1.1. Administratorem serwisu jest KupPixel Sp. z o.o. z siedzibą w Warszawie.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              1.2. Regulamin określa zasady korzystania z usług dostępnych za pośrednictwem
+              serwisu internetowego KupPixel, w szczególności zasady rejestracji, nabywania pól
+              pikselowych oraz publikowania treści.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              1.3. Korzystanie z serwisu wymaga akceptacji regulaminu oraz posiadania aktywnego
+              konta użytkownika.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">2. Rejestracja i konto użytkownika</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              2.1. Rejestracja konta jest dobrowolna i odbywa się poprzez wypełnienie formularza
+              rejestracyjnego oraz potwierdzenie adresu e-mail.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              2.2. Użytkownik zobowiązany jest do podania prawdziwych danych oraz aktualizacji
+              ich w razie zmian. Administrator nie ponosi odpowiedzialności za skutki podania
+              błędnych danych kontaktowych.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              2.3. Użytkownik jest zobowiązany do ochrony danych logowania przed osobami trzecimi.
+              Wszelkie czynności dokonane po zalogowaniu uważa się za działania użytkownika.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">3. Zakup i zarządzanie pikselami</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              3.1. Użytkownik może nabywać piksele zgodnie z obowiązującym cennikiem, wyrażonym w
+              punktach lub innych jednostkach wskazanych w serwisie.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              3.2. Po nabyciu pikseli użytkownik może umieszczać na nich grafiki, linki oraz teksty,
+              o ile nie naruszają one prawa, dobrych obyczajów ani praw osób trzecich.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              3.3. Administrator zastrzega sobie prawo do odmowy publikacji lub usunięcia treści,
+              które naruszają regulamin lub powszechnie obowiązujące przepisy. W takim przypadku
+              użytkownikowi nie przysługuje zwrot poniesionych kosztów, jeżeli naruszenie wynikało z
+              jego zawinionego działania.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">4. Minimalna odpowiedzialność</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              4.1. Administrator ponosi odpowiedzialność wobec użytkownika jedynie w granicach
+              rzeczywistej szkody, będącej bezpośrednim i zawinionym następstwem niewykonania lub
+              nienależytego wykonania usługi. Odpowiedzialność za utracone korzyści jest wyłączona w
+              najszerszym dopuszczalnym przez prawo zakresie.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              4.2. Administrator nie odpowiada za szkody wynikłe z:
+            </p>
+            <ul className="ml-6 list-disc space-y-1 text-sm text-slate-200">
+              <li>działań lub zaniechań użytkownika lub osób trzecich,</li>
+              <li>zdarzeń siły wyższej, awarii sieci telekomunikacyjnych, serwerów lub oprogramowania,</li>
+              <li>zawieszenia lub zakończenia świadczenia usług wynikających z naruszenia regulaminu przez użytkownika.</li>
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">5. Brak gwarancji</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              5.1. Serwis KupPixel świadczony jest w stanie „takim, jaki jest”. Administrator nie
+              udziela żadnej gwarancji, w tym gwarancji przydatności do określonego celu, ciągłej
+              dostępności czy bezbłędnego działania serwisu.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              5.2. Administrator nie gwarantuje skuteczności działań marketingowych prowadzonych przez
+              użytkownika przy użyciu nabytych pikseli ani liczby odwiedzin generowanych przez linki.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">6. Prawo do zmian oferty</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              6.1. Administrator zastrzega sobie prawo do wprowadzania zmian w ofercie serwisu, w tym
+              modyfikacji funkcjonalności, cennika, zasad przyznawania punktów oraz warunków promocji.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              6.2. Zmiany wchodzą w życie w terminie wskazanym w ogłoszeniu zamieszczonym na stronie
+              głównej serwisu. Użytkownicy zostaną o nich poinformowani co najmniej 7 dni wcześniej,
+              chyba że zmiana wynika z nagłej potrzeby zapewnienia bezpieczeństwa serwisu.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              6.3. Kontynuowanie korzystania z serwisu po wejściu w życie zmian oznacza ich akceptację.
+              W przypadku braku zgody użytkownik ma prawo do rozwiązania umowy ze skutkiem natychmiastowym.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">7. Prawa autorskie i treści użytkowników</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              7.1. Użytkownik publikujący treści w serwisie oświadcza, że posiada prawa do ich
+              rozpowszechniania lub uzyskał odpowiednie zgody.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              7.2. Użytkownik udziela administratorowi niewyłącznej licencji na publiczne wyświetlanie
+              oraz przechowywanie publikowanych materiałów w zakresie koniecznym do realizacji usług.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              7.3. Administrator może usuwać treści naruszające prawo lub regulamin, a także blokować
+              konta użytkowników dopuszczających się powtarzających naruszeń.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">8. Reklamacje</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              8.1. Reklamacje dotyczące funkcjonowania serwisu można składać drogą elektroniczną na adres
+              reklamacje@kuppixel.pl w terminie 30 dni od wystąpienia zdarzenia będącego podstawą reklamacji.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              8.2. Reklamacja powinna zawierać dane umożliwiające identyfikację użytkownika oraz opis zgłaszanych
+              zastrzeżeń. Administrator rozpatrzy zgłoszenie w terminie 14 dni roboczych od daty otrzymania.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              8.3. W przypadku braku możliwości rozpatrzenia reklamacji w podanym terminie, administrator poinformuje
+              użytkownika o przyczynach opóźnienia i wskaże przewidywany termin udzielenia odpowiedzi.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">9. Dane osobowe</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              9.1. Administratorem danych osobowych użytkowników jest KupPixel Sp. z o.o. Dane przetwarzane są w
+              celu realizacji usług elektronicznych i obsługi kont użytkownika zgodnie z polityką prywatności.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              9.2. Użytkownikowi przysługuje prawo dostępu do treści swoich danych oraz ich poprawiania, ograniczenia
+              przetwarzania, przenoszenia i usunięcia na zasadach określonych w obowiązujących przepisach.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-blue-200">10. Postanowienia końcowe</h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-200">
+              10.1. W sprawach nieuregulowanych regulaminem zastosowanie mają przepisy prawa polskiego, w szczególności
+              ustawy o świadczeniu usług drogą elektroniczną oraz Kodeksu cywilnego.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              10.2. Spory wynikłe z korzystania z serwisu rozstrzygane będą przez właściwe sądy powszechne. Użytkownik
+              będący konsumentem może skorzystać z pozasądowych sposobów rozpatrywania sporów i dochodzenia roszczeń.
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200">
+              10.3. Regulamin wchodzi w życie z dniem jego publikacji na stronie serwisu.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VerifyAccountPage.tsx
+++ b/frontend/src/components/VerifyAccountPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useAuth } from "../useAuth";
 import ResendVerificationForm from "./ResendVerificationForm";
+import TermsFooter from "./TermsFooter";
 
 type VerifyStatus = "idle" | "loading" | "success" | "error";
 
@@ -71,66 +72,71 @@ export default function VerifyAccountPage() {
   }, [openLoginModal]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-4 py-16 text-center text-slate-200">
-      <div className="w-full max-w-xl rounded-3xl bg-slate-900/80 p-10 shadow-2xl ring-1 ring-white/10">
-        <h1 className="text-3xl font-semibold text-blue-400">Potwierdzenie adresu e-mail</h1>
-        {status === "loading" && (
-          <div className="mt-6 space-y-3 text-sm text-slate-300">
-            <p>Trwa potwierdzanie tokenu weryfikacyjnego...</p>
-            <div className="mx-auto h-2 w-40 overflow-hidden rounded-full bg-slate-800">
-              <div className="h-full w-1/2 animate-pulse rounded-full bg-blue-500" />
-            </div>
-          </div>
-        )}
-
-        {status === "success" && (
-          <div className="mt-8 space-y-6">
-            <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-6 text-left text-emerald-100">
-              <p className="text-lg font-semibold text-emerald-300">Gotowe!</p>
-              <p className="mt-2 text-sm text-emerald-100">{message}</p>
-            </div>
-            <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-              <button
-                type="button"
-                onClick={handleOpenLogin}
-                className="inline-flex items-center justify-center rounded-full bg-blue-500 px-6 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400"
-              >
-                Przejdź do logowania
-              </button>
-              <Link
-                to="/"
-                className="inline-flex items-center justify-center rounded-full bg-slate-800/70 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-700"
-              >
-                Wróć na stronę główną
-              </Link>
-            </div>
-          </div>
-        )}
-
-        {status === "error" && (
-          <div className="mt-8 space-y-6 text-left">
-            <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-6 text-rose-100">
-              <p className="text-lg font-semibold text-rose-200">Nie udało się potwierdzić konta</p>
-              <p className="mt-2 text-sm text-rose-100">{error}</p>
-            </div>
-            <div className="rounded-2xl border border-blue-500/30 bg-blue-500/10 p-6 text-sm text-blue-100">
-              <p className="text-base font-semibold text-blue-200">Wyślij link ponownie</p>
-              <p className="mt-2 text-blue-100/80">Wpisz swój adres e-mail, aby otrzymać nowy token weryfikacyjny.</p>
-              <div className="mt-4">
-                <ResendVerificationForm />
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-200">
+      <main className="flex-1">
+        <div className="flex min-h-full flex-col items-center justify-center px-4 py-16 text-center">
+          <div className="w-full max-w-xl rounded-3xl bg-slate-900/80 p-10 shadow-2xl ring-1 ring-white/10">
+            <h1 className="text-3xl font-semibold text-blue-400">Potwierdzenie adresu e-mail</h1>
+            {status === "loading" && (
+              <div className="mt-6 space-y-3 text-sm text-slate-300">
+                <p>Trwa potwierdzanie tokenu weryfikacyjnego...</p>
+                <div className="mx-auto h-2 w-40 overflow-hidden rounded-full bg-slate-800">
+                  <div className="h-full w-1/2 animate-pulse rounded-full bg-blue-500" />
+                </div>
               </div>
-            </div>
-            <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-              <Link
-                to="/"
-                className="inline-flex items-center justify-center rounded-full bg-slate-800/70 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-700"
-              >
-                Wróć na stronę główną
-              </Link>
-            </div>
+            )}
+
+            {status === "success" && (
+              <div className="mt-8 space-y-6">
+                <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-6 text-left text-emerald-100">
+                  <p className="text-lg font-semibold text-emerald-300">Gotowe!</p>
+                  <p className="mt-2 text-sm text-emerald-100">{message}</p>
+                </div>
+                <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                  <button
+                    type="button"
+                    onClick={handleOpenLogin}
+                    className="inline-flex items-center justify-center rounded-full bg-blue-500 px-6 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400"
+                  >
+                    Przejdź do logowania
+                  </button>
+                  <Link
+                    to="/"
+                    className="inline-flex items-center justify-center rounded-full bg-slate-800/70 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-700"
+                  >
+                    Wróć na stronę główną
+                  </Link>
+                </div>
+              </div>
+            )}
+
+            {status === "error" && (
+              <div className="mt-8 space-y-6 text-left">
+                <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-6 text-rose-100">
+                  <p className="text-lg font-semibold text-rose-200">Nie udało się potwierdzić konta</p>
+                  <p className="mt-2 text-sm text-rose-100">{error}</p>
+                </div>
+                <div className="rounded-2xl border border-blue-500/30 bg-blue-500/10 p-6 text-sm text-blue-100">
+                  <p className="text-base font-semibold text-blue-200">Wyślij link ponownie</p>
+                  <p className="mt-2 text-blue-100/80">Wpisz swój adres e-mail, aby otrzymać nowy token weryfikacyjny.</p>
+                  <div className="mt-4">
+                    <ResendVerificationForm />
+                  </div>
+                </div>
+                <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                  <Link
+                    to="/"
+                    className="inline-flex items-center justify-center rounded-full bg-slate-800/70 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:bg-slate-700"
+                  >
+                    Wróć na stronę główną
+                  </Link>
+                </div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </div>
+      </main>
+      <TermsFooter />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a full Terms & Conditions page and reusable footer prompting users to read it
- wrap public routes in a shared flex layout so the footer is pinned across landing, buy, and error views
- require users to accept the terms before registration succeeds and surface the footer on account-related pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18d84a28483269e7c1da3feac26e0