### PR TITLE
Introduce shared navigation bar across authenticated pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import VerifyAccountPage from "./components/VerifyAccountPage";
 import AccountPage from "./components/AccountPage";
 import ActivationCodeModal from "./components/ActivationCodeModal";
 import TermsFooter from "./components/TermsFooter";
+import NavigationBar from "./components/NavigationBar";
 import TermsPage from "./components/TermsPage";
 import { useAuth } from "./useAuth";
 
@@ -71,15 +72,10 @@ function usePixels() {
   return { data, loading, error } as const;
 }
 
-type LandingPageProps = {
-  onOpenRegister: () => void;
-  onOpenActivationCode: () => void;
-};
-
-function LandingPage({ onOpenRegister, onOpenActivationCode }: LandingPageProps) {
+function LandingPage() {
   const navigate = useNavigate();
   const { data, loading, error } = usePixels();
-  const { user, ensureAuthenticated, openLoginModal, logout, pixelCostPoints } = useAuth();
+  const { user, ensureAuthenticated, pixelCostPoints } = useAuth();
   const [selectedPixels, setSelectedPixels] = useState<Pixel[]>([]);
 
   const handlePixelClick = useCallback(
@@ -160,54 +156,6 @@ function LandingPage({ onOpenRegister, onOpenActivationCode }: LandingPageProps)
             )}
           </div>
         )}
-        <div className="mt-6 flex items-center justify-center gap-4 text-sm text-slate-300">
-          {user ? (
-            <>
-              <span className="rounded-full bg-slate-800/80 px-4 py-2 text-slate-200">
-                Zalogowano jako <span className="font-semibold">{user.email}</span>
-              </span>
-              <button
-                type="button"
-                onClick={onOpenActivationCode}
-                className="rounded-full bg-emerald-500/90 px-4 py-2 font-semibold text-emerald-950 shadow-lg transition hover:bg-emerald-400"
-              >
-                Aktywuj kod
-              </button>
-              <Link
-                to="/account"
-                className="rounded-full bg-slate-800/70 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
-              >
-                Twoje konto
-              </Link>
-              <button
-                type="button"
-                onClick={() => void logout()}
-                className="rounded-full bg-slate-800/70 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
-              >
-                Wyloguj
-              </button>
-            </>
-          ) : (
-            <div className="flex flex-col items-stretch gap-3 sm:flex-row">
-              <button
-                type="button"
-                onClick={onOpenRegister}
-                className="rounded-full bg-blue-500 px-6 py-2 font-semibold text-white shadow-lg transition hover:bg-blue-400"
-              >
-                Załóż konto
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
-                }}
-                className="rounded-full bg-slate-800/70 px-6 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
-              >
-                Zaloguj się
-              </button>
-            </div>
-          )}
-        </div>
       </header>
       <main className="mx-auto flex max-w-5xl flex-col items-center gap-6 px-4 pb-16">
         {loading && <div className="text-slate-300">Ładuję siatkę pikseli...</div>}
@@ -628,9 +576,16 @@ function BuyPixelPage() {
   );
 }
 
-function PageLayout({ children }: { children: ReactNode }) {
+type PageLayoutProps = {
+  children: ReactNode;
+  onOpenRegister?: () => void;
+  onOpenActivationCode?: () => void;
+};
+
+function PageLayout({ children, onOpenRegister, onOpenActivationCode }: PageLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <NavigationBar onOpenRegister={onOpenRegister} onOpenActivationCode={onOpenActivationCode} />
       <main className="flex-1">{children}</main>
       <TermsFooter />
     </div>
@@ -676,17 +631,31 @@ export default function App() {
         <Route
           path="/"
           element={
-            <PageLayout>
-              <LandingPage onOpenRegister={handleOpenRegister} onOpenActivationCode={handleOpenActivationCode} />
+            <PageLayout onOpenRegister={handleOpenRegister} onOpenActivationCode={handleOpenActivationCode}>
+              <LandingPage />
             </PageLayout>
           }
         />
-        <Route path="/account" element={<AccountPage onOpenActivationCode={handleOpenActivationCode} />} />
-        <Route path="/verify" element={<VerifyAccountPage />} />
+        <Route
+          path="/account"
+          element={
+            <PageLayout onOpenActivationCode={handleOpenActivationCode}>
+              <AccountPage onOpenActivationCode={handleOpenActivationCode} />
+            </PageLayout>
+          }
+        />
+        <Route
+          path="/verify"
+          element={
+            <PageLayout onOpenRegister={handleOpenRegister}>
+              <VerifyAccountPage />
+            </PageLayout>
+          }
+        />
         <Route
           path="/buy"
           element={
-            <PageLayout>
+            <PageLayout onOpenRegister={handleOpenRegister} onOpenActivationCode={handleOpenActivationCode}>
               <BuyPixelPage />
             </PageLayout>
           }
@@ -694,7 +663,7 @@ export default function App() {
         <Route
           path="/buy/:pixelId"
           element={
-            <PageLayout>
+            <PageLayout onOpenRegister={handleOpenRegister} onOpenActivationCode={handleOpenActivationCode}>
               <BuyPixelPage />
             </PageLayout>
           }
@@ -702,7 +671,7 @@ export default function App() {
         <Route
           path="/terms"
           element={
-            <PageLayout>
+            <PageLayout onOpenRegister={handleOpenRegister}>
               <TermsPage />
             </PageLayout>
           }
@@ -710,7 +679,7 @@ export default function App() {
         <Route
           path="*"
           element={
-            <PageLayout>
+            <PageLayout onOpenRegister={handleOpenRegister}>
               <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-slate-300">
                 <h2 className="text-2xl font-semibold text-white">Ups! Nie znaleziono strony.</h2>
                 <Link to="/" className="text-blue-400 underline">

--- a/frontend/src/components/AccountPage.tsx
+++ b/frontend/src/components/AccountPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth, type AuthUser } from "../useAuth";
-import TermsFooter from "./TermsFooter";
 
 type AccountPixel = {
   id: number;
@@ -297,20 +296,18 @@ export default function AccountPage({ onOpenActivationCode }: AccountPageProps =
   }, [editValue, editingId, navigate, openLoginModal, pixels]);
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-200">
-      <main className="flex-1">
-        <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-12">
-        <header className="space-y-2 text-center">
-          <h1 className="text-3xl font-semibold text-blue-400">Twoje konto</h1>
-          <p className="text-sm text-slate-400">Zarządzaj zakupionymi pikselami i aktualizuj adresy reklam.</p>
-          {currentUserEmail && (
-            <p className="text-sm text-slate-300">
-              Zalogowano jako <span className="font-semibold text-white">{currentUserEmail}</span>
-            </p>
-          )}
-        </header>
+    <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-12 text-slate-200">
+      <header className="space-y-2 text-center">
+        <h1 className="text-3xl font-semibold text-blue-400">Twoje konto</h1>
+        <p className="text-sm text-slate-400">Zarządzaj zakupionymi pikselami i aktualizuj adresy reklam.</p>
+        {currentUserEmail && (
+          <p className="text-sm text-slate-300">
+            Zalogowano jako <span className="font-semibold text-white">{currentUserEmail}</span>
+          </p>
+        )}
+      </header>
 
-        <section className="grid gap-4 rounded-3xl border border-slate-800 bg-slate-900/70 p-6 shadow-xl sm:grid-cols-2 lg:grid-cols-3">
+      <section className="grid gap-4 rounded-3xl border border-slate-800 bg-slate-900/70 p-6 shadow-xl sm:grid-cols-2 lg:grid-cols-3">
           <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4">
             <p className="text-sm font-semibold text-slate-100">Saldo punktów</p>
             <p className="mt-2 text-2xl font-bold text-emerald-400">{pointsBalance} pkt</p>
@@ -347,9 +344,9 @@ export default function AccountPage({ onOpenActivationCode }: AccountPageProps =
               </button>
             </div>
           </div>
-        </section>
+      </section>
 
-        <div className="rounded-3xl border border-slate-800 bg-slate-900/70 p-6 shadow-xl">
+      <div className="rounded-3xl border border-slate-800 bg-slate-900/70 p-6 shadow-xl">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <h2 className="text-xl font-semibold text-slate-100">Wykupione piksele</h2>
             <Link to="/" className="text-sm font-semibold text-blue-400 hover:text-blue-300">
@@ -474,10 +471,7 @@ export default function AccountPage({ onOpenActivationCode }: AccountPageProps =
               )}
             </div>
           )}
-        </div>
-        </div>
-      </main>
-      <TermsFooter />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useMemo } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { useAuth } from "../useAuth";
+
+type NavigationBarProps = {
+  onOpenRegister?: () => void;
+  onOpenActivationCode?: () => void;
+};
+
+export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: NavigationBarProps) {
+  const { user, openLoginModal, logout } = useAuth();
+  const location = useLocation();
+
+  const displayName = useMemo(() => {
+    if (!user) {
+      return "";
+    }
+    const username = typeof user.username === "string" ? user.username : null;
+    return username && username.trim().length > 0 ? username : user.email;
+  }, [user]);
+
+  const pointsBalance = useMemo(() => {
+    if (typeof user?.points === "number" && Number.isFinite(user.points)) {
+      return user.points;
+    }
+    return 0;
+  }, [user]);
+
+  const handleOpenLogin = useCallback(() => {
+    void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
+  }, [openLoginModal]);
+
+  const handleLogout = useCallback(() => {
+    void logout();
+  }, [logout]);
+
+  const isAccountRoute = location.pathname.startsWith("/account");
+
+  return (
+    <nav className="border-b border-slate-800/80 bg-slate-950/80 backdrop-blur supports-[backdrop-filter]:bg-slate-950/60">
+      <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-4 text-sm text-slate-200 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-6">
+          <Link to="/" className="text-base font-semibold text-blue-400 transition hover:text-blue-300">
+            Home
+          </Link>
+        </div>
+        {user ? (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <div className="flex flex-col items-start gap-1 text-xs text-slate-300 sm:text-sm">
+              <span className="font-semibold text-slate-100">{displayName}</span>
+              <span className="inline-flex items-center rounded-full bg-slate-900/80 px-3 py-1 text-xs font-medium text-emerald-300">
+                Saldo: {pointsBalance} pkt
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {onOpenActivationCode && (
+                <button
+                  type="button"
+                  onClick={onOpenActivationCode}
+                  className="rounded-full bg-emerald-500/90 px-4 py-2 font-semibold text-emerald-950 transition hover:bg-emerald-400"
+                >
+                  Aktywuj kod
+                </button>
+              )}
+              {!isAccountRoute && (
+                <Link
+                  to="/account"
+                  className="rounded-full bg-slate-800/80 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
+                >
+                  Twoje konto
+                </Link>
+              )}
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="rounded-full bg-slate-800/80 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
+              >
+                Wyloguj
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-center gap-2">
+            {onOpenRegister && (
+              <button
+                type="button"
+                onClick={onOpenRegister}
+                className="rounded-full bg-blue-500 px-5 py-2 font-semibold text-white transition hover:bg-blue-400"
+              >
+                Załóż konto
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={handleOpenLogin}
+              className="rounded-full bg-slate-800/80 px-5 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
+            >
+              Zaloguj się
+            </button>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/components/VerifyAccountPage.tsx
+++ b/frontend/src/components/VerifyAccountPage.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useAuth } from "../useAuth";
 import ResendVerificationForm from "./ResendVerificationForm";
-import TermsFooter from "./TermsFooter";
 
 type VerifyStatus = "idle" | "loading" | "success" | "error";
 
@@ -72,10 +71,8 @@ export default function VerifyAccountPage() {
   }, [openLoginModal]);
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-200">
-      <main className="flex-1">
-        <div className="flex min-h-full flex-col items-center justify-center px-4 py-16 text-center">
-          <div className="w-full max-w-xl rounded-3xl bg-slate-900/80 p-10 shadow-2xl ring-1 ring-white/10">
+    <div className="flex min-h-full flex-col items-center justify-center px-4 py-16 text-center text-slate-200">
+      <div className="w-full max-w-xl rounded-3xl bg-slate-900/80 p-10 shadow-2xl ring-1 ring-white/10">
             <h1 className="text-3xl font-semibold text-blue-400">Potwierdzenie adresu e-mail</h1>
             {status === "loading" && (
               <div className="mt-6 space-y-3 text-sm text-slate-300">
@@ -133,10 +130,7 @@ export default function VerifyAccountPage() {
                 </div>
               </div>
             )}
-          </div>
-        </div>
-      </main>
-      <TermsFooter />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an auth-aware NavigationBar that centralizes login, register, activation and logout controls
- update PageLayout to include the shared navigation for all primary routes and simplify duplicated headers
- rely on the global layout footer by removing local footers from account and verification pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a273435c8326979c706f5675b62c