### PR TITLE
Finalize frontend localization and translation cleanup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import TermsFooter from "./components/TermsFooter";
 import NavigationBar from "./components/NavigationBar";
 import TermsPage from "./components/TermsPage";
 import { useAuth } from "./useAuth";
+import { useI18n } from "./lang/I18nProvider";
 
 type PixelResponse = {
   width: number;
@@ -22,6 +23,7 @@ function usePixels() {
   const [data, setData] = useState<PixelResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { t } = useI18n();
 
   useEffect(() => {
     let ignore = false;
@@ -35,15 +37,15 @@ function usePixels() {
           if (response.status === 401) {
             if (!ignore) {
               setData(null);
-              setError("Aby zobaczyć tablicę pikseli, zaloguj się.");
+              setError(t("auth.errors.loginRequired"));
             }
             void openLoginModal({
-              message: "Twoja sesja wygasła. Zaloguj się, aby ponownie zobaczyć tablicę.",
+              message: t("auth.errors.sessionExpired"),
             });
             return;
           }
           const message = await response.text().catch(() => "");
-          throw new Error(message || `Błąd API: ${response.status}`);
+          throw new Error(message || t("auth.errors.api", { status: response.status }));
         }
         const json = (await response.json()) as PixelResponse;
         if (!ignore) {
@@ -53,7 +55,7 @@ function usePixels() {
       } catch (err) {
         console.error(err);
         if (!ignore) {
-          const message = err instanceof Error ? err.message : "Nie udało się pobrać stanu pikseli.";
+          const message = err instanceof Error ? err.message : t("auth.errors.fetchPixels");
           setError(message);
         }
       } finally {
@@ -67,7 +69,7 @@ function usePixels() {
     return () => {
       ignore = true;
     };
-  }, [openLoginModal, user]);
+  }, [openLoginModal, t, user]);
 
   return { data, loading, error } as const;
 }
@@ -77,6 +79,7 @@ function LandingPage() {
   const { data, loading, error } = usePixels();
   const { user, ensureAuthenticated, pixelCostPoints } = useAuth();
   const [selectedPixels, setSelectedPixels] = useState<Pixel[]>([]);
+  const { t, dictionary } = useI18n();
 
   const handlePixelClick = useCallback(
     async (pixel: Pixel) => {
@@ -85,14 +88,14 @@ function LandingPage() {
         return;
       }
       const authenticated = await ensureAuthenticated({
-        message: "Zaloguj się, aby kupić wybrany piksel.",
+        message: t("auth.errors.loginToBuy"),
       });
       if (!authenticated) {
         return;
       }
       navigate(`/buy/${pixel.id}`);
     },
-    [ensureAuthenticated, navigate]
+    [ensureAuthenticated, navigate, t]
   );
 
   const handleSelectionComplete = useCallback(
@@ -106,7 +109,7 @@ function LandingPage() {
       }
 
       const authenticated = await ensureAuthenticated({
-        message: "Zaloguj się, aby kupić zaznaczone piksele.",
+        message: t("auth.errors.loginToBuyMany"),
       });
       if (!authenticated) {
         return;
@@ -121,7 +124,7 @@ function LandingPage() {
         { state: { pixelIds: ids } }
       );
     },
-    [ensureAuthenticated, handlePixelClick, navigate]
+    [ensureAuthenticated, handlePixelClick, navigate, t]
   );
 
   const heroStats = useMemo(() => {
@@ -133,52 +136,85 @@ function LandingPage() {
     return { taken, free: data.pixels.length - taken };
   }, [data]);
 
+  const pointsShort = t("common.units.pointsShort");
+  const formatPoints = useCallback((value: number) => t("common.units.points", { count: value }), [t]);
+
+  const instructionItems = useMemo<ReactNode[]>(() => {
+    const landingSection = (dictionary.landing as Record<string, unknown>) ?? {};
+    const instructions = landingSection.instructions as Record<string, unknown> | undefined;
+    const getInstruction = (key: string) => {
+      const fallbackKey = `landing.instructions.${key}`;
+      if (instructions && typeof instructions[key] === "string") {
+        return instructions[key] as string;
+      }
+      return t(fallbackKey);
+    };
+    const panText = getInstruction("pan");
+    const panParts = panText.split(/(\{\{ctrl\}\}|\{\{shift\}\})/g).filter((part) => part !== "");
+    const panNodes = panParts.map((part, index) => {
+      if (part === "{{ctrl}}") {
+        return (
+          <kbd key={`ctrl-${index}`} className="rounded bg-slate-800 px-1.5 py-0.5 text-xs font-semibold text-slate-100">
+            Ctrl
+          </kbd>
+        );
+      }
+      if (part === "{{shift}}") {
+        return (
+          <kbd key={`shift-${index}`} className="ml-1 rounded bg-slate-800 px-1.5 py-0.5 text-xs font-semibold text-slate-100">
+            Shift
+          </kbd>
+        );
+      }
+      return (
+        <span key={`text-${index}`}>{part}</span>
+      );
+    });
+    return [
+      getInstruction("single"),
+      getInstruction("multi"),
+      <>{panNodes}</>,
+      getInstruction("zoom"),
+    ];
+  }, [dictionary, t]);
+
   return (
     <div className="min-h-screen">
       <header className="py-10 text-center">
-        <h1 className="text-4xl font-bold text-blue-400">Kup Piksel</h1>
-        <p className="mt-2 text-slate-300">
-          Wybierz swój piksel na cyfrowej tablicy 1000×1000 i zostaw po sobie ślad.
-        </p>
+        <h1 className="text-4xl font-bold text-blue-400">{t("landing.title")}</h1>
+        <p className="mt-2 text-slate-300">{t("landing.subtitle")}</p>
         <div className="mt-4 flex items-center justify-center gap-6 text-sm text-slate-400">
-          <span className="font-semibold text-slate-200">Zajęte: {heroStats.taken}</span>
-          <span className="font-semibold text-slate-200">Wolne: {heroStats.free}</span>
+          <span className="font-semibold text-slate-200">{t("landing.stats.taken", { count: heroStats.taken })}</span>
+          <span className="font-semibold text-slate-200">{t("landing.stats.free", { count: heroStats.free })}</span>
         </div>
         {user && (
           <div className="mt-3 text-sm text-slate-300">
             <span className="mr-4 inline-flex items-center rounded-full bg-slate-800/70 px-4 py-1 text-slate-200">
-              Saldo: <span className="ml-1 font-semibold">{typeof user.points === "number" ? user.points : 0} pkt</span>
+              {t("common.labels.balance")}: {" "}
+              <span className="ml-1 font-semibold">
+                {`${typeof user.points === "number" ? user.points : 0} ${pointsShort}`}
+              </span>
             </span>
             {typeof pixelCostPoints === "number" && pixelCostPoints > 0 && (
               <span className="inline-flex items-center rounded-full bg-slate-800/70 px-4 py-1 text-slate-200">
-                Koszt piksela: <span className="ml-1 font-semibold">{pixelCostPoints} pkt</span>
+                {t("common.labels.pixelCost")}: {" "}
+                <span className="ml-1 font-semibold">{`${pixelCostPoints} ${pointsShort}`}</span>
               </span>
             )}
           </div>
         )}
       </header>
       <main className="mx-auto flex max-w-5xl flex-col items-center gap-6 px-4 pb-16">
-        {loading && <div className="text-slate-300">Ładuję siatkę pikseli...</div>}
+        {loading && <div className="text-slate-300">{t("landing.loading")}</div>}
         {error && <div className="text-rose-400">{error}</div>}
         {data && (
           <>
             <div className="w-full max-w-3xl rounded-xl border border-slate-600/70 bg-slate-900/70 px-6 py-4 text-sm text-slate-200 shadow-lg">
-              <h2 className="text-base font-semibold text-slate-100">Jak pracować z tablicą:</h2>
+              <h2 className="text-base font-semibold text-slate-100">{t("landing.instructionsTitle")}</h2>
               <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-300">
-                <li>
-                  Kliknij pojedynczy piksel, aby przejść do edycji lub otworzyć link reklamowy właściciela.
-                </li>
-                <li>
-                  Przeciągnij z wciśniętym lewym przyciskiem myszy, aby zaznaczyć blok wolnych pikseli do wspólnego zakupu.
-                </li>
-                <li>
-                  Przytrzymaj <kbd className="rounded bg-slate-800 px-1.5 py-0.5 text-xs font-semibold text-slate-100">Ctrl</kbd> lub
-                  <kbd className="ml-1 rounded bg-slate-800 px-1.5 py-0.5 text-xs font-semibold text-slate-100">Shift</kbd> i przeciągaj,
-                  aby płynnie przesuwać widok tablicy.
-                </li>
-                <li>
-                  Przy dużym powiększeniu pojawia się siatka pomocnicza, która ułatwia liczenie i precyzyjne ustawianie pikseli.
-                </li>
+                {instructionItems.map((item, index) => (
+                  <li key={`instruction-${index}`}>{item}</li>
+                ))}
               </ul>
             </div>
             <PixelCanvas
@@ -192,13 +228,10 @@ function LandingPage() {
         )}
         {selectedPixels.length > 1 && (
           <div className="w-full max-w-2xl rounded-xl border border-blue-500/20 bg-blue-500/5 px-4 py-3 text-center text-sm text-blue-100">
-            Zaznaczono {selectedPixels.length} wolnych pikseli. Dokończ zakup na stronie formularza, aby zarezerwować wszystkie.
+            {t("landing.selection", { count: selectedPixels.length })}
           </div>
         )}
-        <p className="max-w-2xl text-center text-sm text-slate-400">
-          Wskazówki powyżej pomogą Ci szybko odnaleźć się na tablicy — od pojedynczych kliknięć, przez zaznaczanie obszarów,
-          po płynne przesuwanie i precyzyjną pracę na dużym powiększeniu.
-        </p>
+        <p className="max-w-2xl text-center text-sm text-slate-400">{t("landing.tips")}</p>
       </main>
     </div>
   );
@@ -214,6 +247,7 @@ function BuyPixelPage() {
   const { pixelId } = useParams<{ pixelId: string }>();
   const location = useLocation();
   const { ensureAuthenticated, openLoginModal, user, pixelCostPoints, refresh } = useAuth();
+  const { t } = useI18n();
   const singleId = useMemo(() => {
     if (!pixelId) return null;
     const parsed = Number(pixelId);
@@ -263,6 +297,31 @@ function BuyPixelPage() {
   const [purchaseError, setPurchaseError] = useState<string | null>(null);
   const [url, setUrl] = useState("https://example.com");
   const [pixelResults, setPixelResults] = useState<PixelPurchaseResult[]>([]);
+  const pointsShort = t("common.units.pointsShort");
+  const selectedIdsLabel = selectedIds.join(", ");
+  const firstSelectedId = selectedIds[0];
+  const pageTitle = selectedCount > 1 ? t("buy.titleMultiple") : t("buy.titleSingle");
+  const description =
+    selectedCount > 1
+      ? t("buy.descriptionMultiple", { count: selectedCount, ids: selectedIdsLabel })
+      : t("buy.descriptionSingle", {
+          id: typeof firstSelectedId === "number" ? firstSelectedId : t("buy.unknownPixel"),
+        });
+  const costDisplay =
+    typeof pixelCostPoints === "number" && pixelCostPoints > 0
+      ? selectedCount > 1 && totalCost !== null
+        ? t("buy.costBreakdown", {
+            count: selectedCount,
+            price: pixelCostPoints,
+            unit: pointsShort,
+            total: totalCost,
+          })
+        : t("buy.singlePrice", { price: pixelCostPoints })
+      : t("buy.configure");
+  const balanceDisplay =
+    typeof user?.points === "number"
+      ? t("common.units.points", { count: user.points })
+      : t("buy.balanceLogin");
 
   useEffect(() => {
     setSelectedColor("#ff4d4f");
@@ -283,7 +342,7 @@ function BuyPixelPage() {
 
   const handleSimulatePurchase = useCallback(async () => {
     if (selectedIds.length === 0) {
-      setPurchaseError("Wybierz co najmniej jeden piksel, aby kontynuować.");
+      setPurchaseError(t("auth.errors.selectionRequired"));
       return;
     }
 
@@ -294,10 +353,10 @@ function BuyPixelPage() {
 
     try {
       const authenticated = await ensureAuthenticated({
-        message: "Zaloguj się, aby kupić zaznaczone piksele.",
+        message: t("auth.errors.loginToBuyMany"),
       });
       if (!authenticated) {
-        throw new Error("Aby kontynuować, zaloguj się.");
+        throw new Error(t("auth.errors.requiresLogin"));
       }
       const response = await fetch("/api/pixels", {
         method: "POST",
@@ -312,8 +371,8 @@ function BuyPixelPage() {
 
       if (!response.ok) {
         if (response.status === 401) {
-          void openLoginModal({ message: "Zaloguj się ponownie, aby sfinalizować zakup." });
-          throw new Error("Twoja sesja wygasła. Zaloguj się ponownie.");
+          void openLoginModal({ message: t("auth.errors.loginToFinish") });
+          throw new Error(t("auth.errors.sessionExpired"));
         }
         const payload = await response.json().catch(() => null);
         if (payload && Array.isArray((payload as { results?: unknown }).results)) {
@@ -341,10 +400,10 @@ function BuyPixelPage() {
             : null;
         if (response.status === 400 || response.status === 403) {
           throw new Error(
-            apiMessage || "Brak wystarczającej liczby punktów, aby kupić piksel. Aktywuj kod i spróbuj ponownie."
+            apiMessage || t("auth.errors.insufficientPoints")
           );
         }
-        throw new Error(apiMessage || `Błąd API: ${response.status}`);
+        throw new Error(apiMessage || t("auth.errors.api", { status: response.status }));
       }
 
       const payload = (await response.json().catch(() => null)) as
@@ -381,79 +440,48 @@ function BuyPixelPage() {
       } else if (successfulCount > 0) {
         setPurchaseStatus("partial");
         await refresh().catch(() => undefined);
-        setPurchaseError("Nie wszystkie piksele udało się kupić. Sprawdź szczegóły poniżej.");
+        setPurchaseError(t("auth.messages.simulationPartial"));
       } else {
         const errorMessage =
           (payload && typeof payload === "object" && typeof (payload as Record<string, unknown>).error === "string"
             ? ((payload as Record<string, unknown>).error as string)
             : null) ||
-          "Nie udało się zarezerwować żadnego z zaznaczonych pikseli. Spróbuj ponownie.";
+          t("auth.errors.purchase");
         setPurchaseError(errorMessage);
       }
     } catch (error) {
       console.error(error);
-      const message = error instanceof Error ? error.message : "Nie udało się zarezerwować piksela. Spróbuj ponownie.";
+      const message = error instanceof Error ? error.message : t("auth.errors.purchase");
       setPurchaseError(message);
     } finally {
       setIsProcessing(false);
     }
-  }, [ensureAuthenticated, openLoginModal, refresh, selectedColor, selectedIds, url]);
+  }, [ensureAuthenticated, openLoginModal, refresh, selectedColor, selectedIds, t, url]);
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-6 py-12 text-center">
       <div className="w-full max-w-2xl rounded-3xl bg-slate-900/60 p-10 shadow-xl">
-        <h2 className="text-3xl font-semibold text-blue-400">
-          {selectedCount > 1 ? "Kup wybrane piksele" : "Kup ten piksel"}
-        </h2>
-        <p className="mt-3 text-slate-300">
-          {selectedCount > 1 ? (
-            <>
-              Wybrałeś {selectedCount} wolnych pikseli o ID: {" "}
-              <span className="font-mono text-white">{selectedIds.join(", ")}</span>. Tutaj możesz dobrać kolor i przejść przez
-              fikcyjny proces płatności, aby zobaczyć, jak będzie działał prawdziwy checkout.
-            </>
-          ) : (
-            <>
-              Wybrałeś piksel o ID {" "}
-              <span className="font-mono text-white">{selectedIds[0] ?? "nieznany"}</span>. Tutaj możesz dobrać kolor i przejść
-              przez fikcyjny proces płatności, aby zobaczyć, jak będzie działał prawdziwy checkout.
-            </>
-          )}
-        </p>
+        <h2 className="text-3xl font-semibold text-blue-400">{pageTitle}</h2>
+        <p className="mt-3 text-slate-300">{description}</p>
 
         <div className="mt-6 grid gap-3 text-left text-sm text-slate-300 sm:grid-cols-2">
           <div className="rounded-xl border border-slate-800/70 bg-slate-900/70 p-4">
-            <p className="font-semibold text-slate-100">Koszt zakupu</p>
-            <p className="mt-1 text-slate-300">
-              {typeof pixelCostPoints === "number" && pixelCostPoints > 0 ? (
-                selectedCount > 1 && totalCost !== null ? (
-                  <>
-                    {selectedCount} × {pixelCostPoints} pkt = {totalCost} punktów
-                  </>
-                ) : (
-                  `${pixelCostPoints} punktów`
-                )
-              ) : (
-                "Sprawdź konfigurację"
-              )}
-            </p>
+            <p className="font-semibold text-slate-100">{t("buy.costTitle")}</p>
+            <p className="mt-1 text-slate-300">{costDisplay}</p>
           </div>
           <div className="rounded-xl border border-slate-800/70 bg-slate-900/70 p-4">
-            <p className="font-semibold text-slate-100">Twoje saldo</p>
-            <p className="mt-1 text-slate-300">{typeof user?.points === "number" ? `${user.points} punktów` : "Zaloguj się"}</p>
+            <p className="font-semibold text-slate-100">{t("buy.balanceTitle")}</p>
+            <p className="mt-1 text-slate-300">{balanceDisplay}</p>
           </div>
         </div>
 
         <div className="mt-8 rounded-2xl bg-slate-800/70 p-6 text-left">
-          <h3 className="text-lg font-semibold text-slate-100">Dopasuj swój piksel</h3>
-          <p className="mt-1 text-sm text-slate-400">
-            Wybierz kolor, który najlepiej reprezentuje Twoją markę – podgląd i wartość HEX aktualizują się
-            automatycznie.
-          </p>
+          <h3 className="text-lg font-semibold text-slate-100">{t("buy.matchTitle")}</h3>
+          <p className="mt-1 text-sm text-slate-400">{t("buy.matchDescription")}</p>
 
           <div className="mt-6 flex flex-col gap-6 sm:flex-row sm:items-center">
             <label className="flex flex-col gap-3 text-sm font-medium text-slate-200" htmlFor="pixel-color">
-              Kolor piksela
+              {t("common.labels.pixelColor")}
               <input
                 id="pixel-color"
                 type="color"
@@ -478,19 +506,17 @@ function BuyPixelPage() {
           </div>
 
           <label className="mt-6 flex flex-col gap-2 text-sm font-medium text-slate-200" htmlFor="pixel-url">
-            Adres URL reklamy
+            {t("common.labels.pixelUrl")}
             <input
               id="pixel-url"
               type="url"
               value={url}
               onChange={handleUrlChange}
               disabled={isProcessing}
-              placeholder="https://twoja-domena.pl"
+              placeholder={t("common.placeholders.pixelUrl")}
               className="w-full rounded-lg border border-slate-700 bg-slate-900/80 px-4 py-3 text-sm text-slate-100 shadow-inner placeholder:text-slate-500"
             />
-            <span className="text-xs font-normal text-slate-400">
-              Po kliknięciu w piksel użytkownik zostanie przekierowany pod ten adres.
-            </span>
+            <span className="text-xs font-normal text-slate-400">{t("buy.urlHint")}</span>
           </label>
 
           <button
@@ -502,17 +528,17 @@ function BuyPixelPage() {
             {isProcessing ? (
               <span className="flex items-center gap-3">
                 <span className="h-2 w-2 animate-ping rounded-full bg-white" />
-                Przetwarzanie płatności...
+                {t("common.status.processing")}
               </span>
             ) : (
-              (selectedCount > 1 ? `Zasymuluj zakup ${selectedCount} pikseli` : "Zasymuluj zakup")
+              selectedCount > 1 ? t("buy.simulateMultiple", { count: selectedCount }) : t("buy.simulateSingle")
             )}
           </button>
 
           <p aria-live="polite" className="mt-4 text-sm text-slate-400">
             {isProcessing
-              ? "Trwa wirtualne potwierdzanie płatności. To potrwa tylko chwilkę..."
-              : "Symulacja nie pobiera prawdziwych środków – to jedynie podgląd przyszłego doświadczenia."}
+              ? t("auth.messages.simulationProcessing")
+              : t("auth.messages.simulationInfo")}
           </p>
 
           {purchaseError && (
@@ -522,7 +548,7 @@ function BuyPixelPage() {
           )}
           {pixelResults.length > 0 && (
             <div className="mt-6 rounded-xl border border-slate-700 bg-slate-900/60 p-4">
-              <h4 className="text-sm font-semibold text-slate-200">Rezultaty zakupu</h4>
+              <h4 className="text-sm font-semibold text-slate-200">{t("buy.resultsTitle")}</h4>
               <ul className="mt-3 space-y-2 text-sm text-slate-300">
                 {pixelResults.map((result) => (
                   <li key={result.id} className="flex items-start justify-between gap-4">
@@ -530,7 +556,11 @@ function BuyPixelPage() {
                     {result.error ? (
                       <span className="text-rose-400">{result.error}</span>
                     ) : (
-                      <span className="text-emerald-300">{result.status === "taken" ? "Kupiono" : result.status}</span>
+                      <span className="text-emerald-300">
+                        {result.status && result.status !== "taken"
+                          ? result.status
+                          : t("buy.resultStatus.taken")}
+                      </span>
                     )}
                   </li>
                 ))}
@@ -544,31 +574,27 @@ function BuyPixelPage() {
             role="status"
             className="mt-8 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-6 text-left text-emerald-100"
           >
-            <h3 className="text-xl font-semibold text-emerald-300">Udało się!</h3>
+            <h3 className="text-xl font-semibold text-emerald-300">{t("buy.successTitle")}</h3>
             <p className="mt-2 text-sm">
-              {selectedCount > 1 ? (
-                <>
-                  Wszystkie {selectedCount} piksele zostały zarezerwowane z kolorem {" "}
-                  <span className="font-mono">{selectedColor.toUpperCase()}</span>.
-                </>
-              ) : (
-                <>
-                  Piksel <span className="font-mono">#{selectedIds[0]}</span> został zarezerwowany z kolorem {" "}
-                  <span className="font-mono">{selectedColor.toUpperCase()}</span>.
-                </>
-              )}
+              {selectedCount > 1
+                ? t("buy.successDescriptionMultiple", {
+                    count: selectedCount,
+                    color: selectedColor.toUpperCase(),
+                  })
+                : t("buy.successDescriptionSingle", {
+                    id: selectedIds[0] ?? t("buy.unknownPixel"),
+                    color: selectedColor.toUpperCase(),
+                  })}
             </p>
             <div className="mt-4 flex items-center gap-3">
-              <span className="text-sm text-emerald-200">Podgląd:</span>
+              <span className="text-sm text-emerald-200">{t("buy.successPreview")}</span>
               <div
                 aria-hidden
                 className="h-8 w-8 rounded border border-emerald-300 shadow-inner"
                 style={{ backgroundColor: selectedColor }}
               />
             </div>
-            <p className="mt-4 text-xs text-emerald-200/80">
-              To wciąż makieta płatności – w produkcji dodasz prawdziwy checkout oraz potwierdzenia dla klienta.
-            </p>
+            <p className="mt-4 text-xs text-emerald-200/80">{t("buy.successMockInfo")}</p>
           </div>
         )}
         {purchaseStatus === "partial" && (
@@ -576,11 +602,8 @@ function BuyPixelPage() {
             role="status"
             className="mt-8 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-6 text-left text-amber-100"
           >
-            <h3 className="text-xl font-semibold text-amber-200">Częściowy sukces</h3>
-            <p className="mt-2 text-sm">
-              Część pikseli została zakupiona, ale kilka wymaga ponownej próby. Sprawdź szczegóły powyżej i spróbuj ponownie
-              po rozwiązaniu problemów.
-            </p>
+            <h3 className="text-xl font-semibold text-amber-200">{t("buy.partialTitle")}</h3>
+            <p className="mt-2 text-sm">{t("buy.partialDescription")}</p>
           </div>
         )}
 
@@ -589,7 +612,7 @@ function BuyPixelPage() {
             to="/"
             className="inline-flex items-center justify-center rounded-full bg-blue-500 px-6 py-2 font-semibold text-white transition hover:bg-blue-400"
           >
-            Wróć na tablicę
+            {t("buy.return")}
           </Link>
         </div>
       </div>
@@ -617,6 +640,7 @@ export default function App() {
   const { openLoginModal, refresh } = useAuth();
   const [isRegisterOpen, setIsRegisterOpen] = useState(false);
   const [isActivationModalOpen, setIsActivationModalOpen] = useState(false);
+  const { t } = useI18n();
 
   const handleOpenRegister = useCallback(() => {
     setIsRegisterOpen(true);
@@ -627,8 +651,8 @@ export default function App() {
   }, []);
 
   const handleOpenLoginFromRegister = useCallback(() => {
-    void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
-  }, [openLoginModal]);
+    void openLoginModal({ message: t("auth.errors.loginToStart") });
+  }, [openLoginModal, t]);
 
   const handleOpenActivationCode = useCallback(() => {
     setIsActivationModalOpen(true);
@@ -702,9 +726,9 @@ export default function App() {
           element={
             <PageLayout onOpenRegister={handleOpenRegister}>
               <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-slate-300">
-                <h2 className="text-2xl font-semibold text-white">Ups! Nie znaleziono strony.</h2>
+                <h2 className="text-2xl font-semibold text-white">{t("notFound.title")}</h2>
                 <Link to="/" className="text-blue-400 underline">
-                  Wróć na tablicę pikseli
+                  {t("notFound.cta")}
                 </Link>
               </div>
             </PageLayout>

--- a/frontend/src/components/ActivationCodeModal.tsx
+++ b/frontend/src/components/ActivationCodeModal.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "../useAuth";
 import { isActivationCodeValid, normalizeActivationCode } from "../utils/activationCode";
+import { useI18n } from "../lang/I18nProvider";
 
 type ActivationCodeModalProps = {
   isOpen: boolean;
@@ -23,6 +24,7 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { t } = useI18n();
 
   const resetState = useCallback(() => {
     setCode("");
@@ -52,7 +54,7 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
 
       const normalized = normalizeActivationCode(code);
       if (!isActivationCodeValid(normalized)) {
-        setError("Kod musi mieć format XXXX-XXXX-XXXX-XXXX i składać się z cyfr lub liter.");
+        setError(t("auth.errors.activationFormat"));
         return;
       }
 
@@ -69,13 +71,13 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
 
         if (!response.ok) {
           if (response.status === 401) {
-            throw new Error("Twoja sesja wygasła. Zaloguj się ponownie i spróbuj jeszcze raz.");
+            throw new Error(t("auth.errors.sessionExpiredLong"));
           }
           const payload = (await response.json().catch(() => null)) as RedeemResponse | null;
           const message =
             payload && typeof payload.error === "string"
               ? (payload.error as string)
-              : "Nie udało się aktywować kodu. Upewnij się, że nie został już użyty.";
+              : t("auth.errors.activateCode");
           throw new Error(message);
         }
 
@@ -86,11 +88,10 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
 
         setCode("");
         if (addedPoints && addedPoints > 0) {
-          setSuccessMessage(`Kod aktywowany! Dodano ${addedPoints} punktów${
-            typeof totalPoints === "number" ? ` (razem ${totalPoints} pkt).` : "."
-          }`);
+          const suffix = typeof totalPoints === "number" ? t("auth.messages.activationSuffix", { total: totalPoints }) : "";
+          setSuccessMessage(t("auth.messages.activationSuccessWithPoints", { added: addedPoints, suffix }));
         } else {
-          setSuccessMessage("Kod został aktywowany.");
+          setSuccessMessage(t("auth.messages.activationSuccess"));
         }
         setError(null);
         if (onSuccess) {
@@ -98,21 +99,21 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
         }
       } catch (err) {
         console.error("redeem activation code", err);
-        const message = err instanceof Error ? err.message : "Nie udało się aktywować kodu.";
+        const message = err instanceof Error ? err.message : t("auth.errors.activateCode");
         setError(message);
       } finally {
         setIsSubmitting(false);
       }
     },
-    [code, isSubmitting, onSuccess]
+    [code, isSubmitting, onSuccess, t]
   );
 
   const infoText = useMemo(() => {
     if (typeof pixelCostPoints === "number" && Number.isFinite(pixelCostPoints)) {
-      return `Koszt jednego piksela to ${pixelCostPoints} punktów.`;
+      return t("auth.messages.activationCost", { points: pixelCostPoints });
     }
-    return "Aktywuj kod, aby otrzymać punkty i kupować piksele.";
-  }, [pixelCostPoints]);
+    return t("auth.messages.activationInfo");
+  }, [pixelCostPoints, t]);
 
   if (!isOpen) {
     return null;
@@ -123,17 +124,17 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
       <div className="w-full max-w-lg rounded-3xl bg-slate-950/95 p-8 shadow-2xl ring-1 ring-white/10" role="dialog" aria-modal="true">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-2xl font-semibold text-slate-100">Aktywuj kod punktowy</h2>
+            <h2 className="text-2xl font-semibold text-slate-100">{t("activationModal.title")}</h2>
             <p className="mt-1 text-sm text-slate-400">{infoText}</p>
             {typeof user?.points === "number" && (
-              <p className="mt-1 text-xs text-slate-400">Aktualne saldo: {user.points} pkt</p>
+              <p className="mt-1 text-xs text-slate-400">{t("activationModal.currentBalance", { points: user.points })}</p>
             )}
           </div>
           <button
             type="button"
             onClick={handleClose}
             className="rounded-full bg-slate-800/80 px-2 py-1 text-lg leading-none text-slate-300 transition hover:text-slate-100"
-            aria-label="Zamknij"
+            aria-label={t("common.actions.close")}
           >
             ×
           </button>
@@ -141,7 +142,7 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
 
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
           <label className="block text-sm font-medium text-slate-200" htmlFor="activation-code">
-            Kod aktywacyjny
+            {t("common.labels.activationCode")}
             <input
               id="activation-code"
               type="text"
@@ -151,7 +152,7 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
                 setError(null);
               }}
               className="mt-2 w-full rounded-xl border border-slate-800 bg-slate-950/70 px-4 py-3 font-mono text-sm uppercase tracking-[0.3em] text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none"
-              placeholder="XXXX-XXXX-XXXX-XXXX"
+              placeholder={t("common.placeholders.activationCode")}
               maxLength={19}
               disabled={isSubmitting}
               autoFocus
@@ -176,14 +177,14 @@ export default function ActivationCodeModal({ isOpen, onClose, onSuccess }: Acti
               className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
               disabled={isSubmitting}
             >
-              Zamknij
+              {t("common.actions.close")}
             </button>
             <button
               type="submit"
               className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-emerald-950 shadow-lg transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
               disabled={isSubmitting}
             >
-              {isSubmitting ? "Aktywuję..." : "Aktywuj"}
+              {isSubmitting ? t("activationModal.submitting") : t("activationModal.submit")}
             </button>
           </div>
         </form>

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useCallback, useMemo, useState } from "react";
 import { useAuth } from "../useAuth";
 import ResendVerificationForm from "./ResendVerificationForm";
+import { useI18n } from "../lang/I18nProvider";
 
 export default function LoginModal() {
   const { isLoginModalOpen, closeLoginModal, login, loginPrompt } = useAuth();
@@ -8,6 +9,7 @@ export default function LoginModal() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { t } = useI18n();
 
   const resetState = useCallback(() => {
     setEmail("");
@@ -32,13 +34,13 @@ export default function LoginModal() {
         resetState();
       } catch (err) {
         console.error("login error", err);
-        const message = err instanceof Error ? err.message : "Nie udało się zalogować.";
+        const message = err instanceof Error ? err.message : t("auth.errors.login");
         setError(message);
       } finally {
         setIsSubmitting(false);
       }
     },
-    [email, login, password, resetState]
+    [email, login, password, resetState, t]
   );
 
   const showResend = useMemo(() => {
@@ -60,16 +62,14 @@ export default function LoginModal() {
       >
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-2xl font-semibold text-slate-100">Zaloguj się</h2>
-            <p className="mt-1 text-sm text-slate-400">
-              {loginPrompt || "Podaj dane logowania, aby kontynuować."}
-            </p>
+            <h2 className="text-2xl font-semibold text-slate-100">{t("loginModal.title")}</h2>
+            <p className="mt-1 text-sm text-slate-400">{loginPrompt || t("auth.messages.loginModalDefault")}</p>
           </div>
           <button
             type="button"
             onClick={handleClose}
             className="rounded-full bg-slate-800/80 p-2 text-slate-400 transition hover:text-slate-200"
-            aria-label="Zamknij"
+            aria-label={t("common.actions.close")}
           >
             ×
           </button>
@@ -77,7 +77,7 @@ export default function LoginModal() {
 
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
           <label className="block text-sm font-medium text-slate-200">
-            Adres e-mail
+            {t("common.labels.email")}
             <input
               type="email"
               value={email}
@@ -91,7 +91,7 @@ export default function LoginModal() {
           </label>
 
           <label className="block text-sm font-medium text-slate-200">
-            Hasło
+            {t("common.labels.password")}
             <input
               type="password"
               value={password}
@@ -110,7 +110,7 @@ export default function LoginModal() {
           )}
           {showResend && (
             <div className="rounded-xl border border-blue-500/30 bg-blue-500/10 p-4 text-sm text-blue-100">
-              <p className="mb-3">Nie otrzymałeś wiadomości? Wyślij ponownie link weryfikacyjny.</p>
+              <p className="mb-3">{t("auth.messages.resendPrompt")}</p>
               <ResendVerificationForm initialEmail={email} className="space-y-3" />
             </div>
           )}
@@ -122,14 +122,14 @@ export default function LoginModal() {
               className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
               disabled={isSubmitting}
             >
-              Anuluj
+              {t("common.actions.cancel")}
             </button>
             <button
               type="submit"
               className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
               disabled={isSubmitting}
             >
-              {isSubmitting ? "Logowanie..." : "Zaloguj"}
+              {isSubmitting ? t("loginModal.submitting") : t("loginModal.submit")}
             </button>
           </div>
         </form>

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useMemo } from "react";
+import { ChangeEvent, useCallback, useMemo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "../useAuth";
+import { useI18n } from "../lang/I18nProvider";
+import { LanguageCode } from "../lang";
 
 type NavigationBarProps = {
   onOpenRegister?: () => void;
@@ -10,6 +12,7 @@ type NavigationBarProps = {
 export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: NavigationBarProps) {
   const { user, openLoginModal, logout } = useAuth();
   const location = useLocation();
+  const { t, availableLanguages, language, setLanguage } = useI18n();
 
   const displayName = useMemo(() => {
     if (!user) {
@@ -27,12 +30,19 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
   }, [user]);
 
   const handleOpenLogin = useCallback(() => {
-    void openLoginModal({ message: "Zaloguj się, aby rozpocząć." });
-  }, [openLoginModal]);
+    void openLoginModal({ message: t("navigation.loginPrompt") });
+  }, [openLoginModal, t]);
 
   const handleLogout = useCallback(() => {
     void logout();
   }, [logout]);
+
+  const handleLanguageChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setLanguage(event.target.value as LanguageCode);
+    },
+    [setLanguage]
+  );
 
   const isAccountRoute = location.pathname.startsWith("/account");
 
@@ -41,15 +51,30 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
       <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-4 text-sm text-slate-200 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-6">
           <Link to="/" className="text-base font-semibold text-blue-400 transition hover:text-blue-300">
-            Home
+            {t("navigation.home")}
           </Link>
+          <label className="flex items-center gap-2 text-xs text-slate-400">
+            <span>{t("common.languageLabel")}:</span>
+            <select
+              value={language}
+              onChange={handleLanguageChange}
+              className="rounded-full border border-slate-700 bg-slate-900/70 px-2 py-1 text-xs text-slate-200"
+              aria-label={t("common.languageLabel")}
+            >
+              {availableLanguages.map((item) => (
+                <option key={item.code} value={item.code} className="text-black">
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
         {user ? (
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
             <div className="flex flex-col items-start gap-1 text-xs text-slate-300 sm:text-sm">
               <span className="font-semibold text-slate-100">{displayName}</span>
               <span className="inline-flex items-center rounded-full bg-slate-900/80 px-3 py-1 text-xs font-medium text-emerald-300">
-                Saldo: {pointsBalance} pkt
+                {t("navigation.balance", { points: pointsBalance })}
               </span>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -59,7 +84,7 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
                   onClick={onOpenActivationCode}
                   className="rounded-full bg-emerald-500/90 px-4 py-2 font-semibold text-emerald-950 transition hover:bg-emerald-400"
                 >
-                  Aktywuj kod
+                  {t("common.actions.activateCode")}
                 </button>
               )}
               {!isAccountRoute && (
@@ -67,7 +92,7 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
                   to="/account"
                   className="rounded-full bg-slate-800/80 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
                 >
-                  Twoje konto
+                  {t("navigation.account")}
                 </Link>
               )}
               <button
@@ -75,7 +100,7 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
                 onClick={handleLogout}
                 className="rounded-full bg-slate-800/80 px-4 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
               >
-                Wyloguj
+                {t("common.actions.logout")}
               </button>
             </div>
           </div>
@@ -87,7 +112,7 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
                 onClick={onOpenRegister}
                 className="rounded-full bg-blue-500 px-5 py-2 font-semibold text-white transition hover:bg-blue-400"
               >
-                Załóż konto
+                {t("common.actions.openRegister")}
               </button>
             )}
             <button
@@ -95,7 +120,7 @@ export default function NavigationBar({ onOpenRegister, onOpenActivationCode }: 
               onClick={handleOpenLogin}
               className="rounded-full bg-slate-800/80 px-5 py-2 font-semibold text-slate-200 transition hover:bg-slate-700"
             >
-              Zaloguj się
+              {t("common.actions.loginCta")}
             </button>
           </div>
         )}

--- a/frontend/src/components/PixelCanvas.tsx
+++ b/frontend/src/components/PixelCanvas.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, WheelEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
+import { useI18n } from "../lang/I18nProvider";
 
 export type Pixel = {
   id: number;
@@ -68,6 +69,7 @@ export default function PixelCanvas({
   const preventClickRef = useRef(false);
   const isPanningRef = useRef(false);
   const lastPanPositionRef = useRef<{ x: number; y: number } | null>(null);
+  const { t } = useI18n();
 
   const MIN_WINDOW_SIZE = 3;
   const ZOOM_STEP = 1.25;
@@ -490,7 +492,7 @@ export default function PixelCanvas({
             } as CSSProperties;
           })()}
         >
-          <span className="sr-only">{previewPixels.length} wolnych pikseli zaznaczonych</span>
+          <span className="sr-only">{t("pixelCanvas.selection", { count: previewPixels.length })}</span>
         </div>
       )}
       <div className="mt-3 flex justify-center gap-3">

--- a/frontend/src/components/RegisterModal.tsx
+++ b/frontend/src/components/RegisterModal.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../useAuth";
 import ResendVerificationForm from "./ResendVerificationForm";
+import { useI18n } from "../lang/I18nProvider";
 
 type RegisterModalProps = {
   isOpen: boolean;
@@ -18,6 +19,9 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const { t } = useI18n();
+  const termsTemplate = t("registerModal.terms", { termsLink: "__LINK__" });
+  const [termsPrefix, termsSuffix = ""] = termsTemplate.split("__LINK__");
 
   const resetState = useCallback(() => {
     setEmail("");
@@ -40,7 +44,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
       event.preventDefault();
       setError(null);
       if (!acceptedTerms) {
-        setError("Aby utworzyć konto, zaakceptuj regulamin.");
+        setError(t("auth.messages.registerTermsError"));
         return;
       }
       setIsSubmitting(true);
@@ -51,13 +55,13 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
         setSuccessMessage(result.message);
       } catch (err) {
         console.error("register error", err);
-        const message = err instanceof Error ? err.message : "Nie udało się utworzyć konta.";
+        const message = err instanceof Error ? err.message : t("auth.errors.register");
         setError(message);
       } finally {
         setIsSubmitting(false);
       }
     },
-    [acceptedTerms, email, password, register]
+    [acceptedTerms, email, password, register, t]
   );
 
   if (!isOpen) {
@@ -74,20 +78,19 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
         <div className="flex items-start justify-between gap-4">
           <div>
             <h2 className="text-2xl font-semibold text-slate-100">
-              {isSuccess ? "Potwierdź adres e-mail" : "Załóż konto"}
+              {isSuccess ? t("registerModal.successTitle") : t("registerModal.title")}
             </h2>
             <p className="mt-1 text-sm text-slate-400">
               {isSuccess
-                ? successMessage ??
-                  "Wysłaliśmy do Ciebie wiadomość z linkiem aktywacyjnym. Kliknij go, aby dokończyć rejestrację."
-                : "Podaj adres e-mail i hasło, aby utworzyć konto i rozpocząć zabawę z tablicą pikseli."}
+                ? successMessage ?? t("auth.messages.registerEmailInfo")
+                : t("auth.messages.registerInfo")}
             </p>
           </div>
           <button
             type="button"
             onClick={handleClose}
             className="rounded-full bg-slate-800/80 p-2 text-slate-400 transition hover:text-slate-200"
-            aria-label="Zamknij"
+            aria-label={t("common.actions.close")}
           >
             ×
           </button>
@@ -96,9 +99,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
         {isSuccess ? (
           <div className="mt-6 space-y-6">
             <div className="rounded-xl border border-blue-500/30 bg-blue-500/10 p-4 text-sm text-blue-100">
-              <p>
-                Nie widzisz wiadomości? Sprawdź folder spam lub poczekaj kilka minut. Możesz też wysłać link ponownie poniżej.
-              </p>
+              <p>{t("auth.messages.registerHelp")}</p>
             </div>
             <ResendVerificationForm initialEmail={email} />
             <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
@@ -112,7 +113,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
                   }}
                   className="text-left text-sm font-semibold text-blue-300 transition hover:text-blue-200"
                 >
-                  Przejdź do logowania
+                  {t("common.actions.openLogin")}
                 </button>
               )}
               <button
@@ -120,14 +121,14 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
                 onClick={handleClose}
                 className="self-end rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
               >
-                Zamknij
+                {t("common.actions.close")}
               </button>
             </div>
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="mt-6 space-y-4">
             <label className="block text-sm font-medium text-slate-200">
-              Adres e-mail
+              {t("common.labels.email")}
               <input
                 type="email"
                 value={email}
@@ -141,7 +142,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
             </label>
 
             <label className="block text-sm font-medium text-slate-200">
-              Hasło
+              {t("common.labels.password")}
               <input
                 type="password"
                 value={password}
@@ -167,11 +168,11 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
                 className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-900 text-blue-500 focus:ring-blue-400"
               />
               <span>
-                Akceptuję {" "}
+                {termsPrefix}
                 <Link to="/terms" className="font-semibold text-blue-300 underline-offset-2 hover:underline">
-                  Regulamin
-                </Link>{" "}
-                serwisu.
+                  {t("registerModal.termsLink")}
+                </Link>
+                {termsSuffix}
               </span>
             </label>
 
@@ -193,7 +194,7 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
                   }}
                   className="text-left text-sm font-semibold text-blue-300 transition hover:text-blue-200"
                 >
-                  Masz już konto? Zaloguj się
+                  {t("registerModal.loginCta")}
                 </button>
               )}
               <div className="flex items-center justify-end gap-3 sm:justify-end">
@@ -203,14 +204,14 @@ export default function RegisterModal({ isOpen, onClose, onOpenLogin }: Register
                   className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
                   disabled={isSubmitting}
                 >
-                  Anuluj
+                  {t("common.actions.cancel")}
                 </button>
                 <button
                   type="submit"
                   className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
                   disabled={isSubmitting || !acceptedTerms}
                 >
-                  {isSubmitting ? "Tworzenie..." : "Zarejestruj się"}
+                  {isSubmitting ? t("registerModal.submitting") : t("registerModal.submit")}
                 </button>
               </div>
             </div>

--- a/frontend/src/components/ResendVerificationForm.tsx
+++ b/frontend/src/components/ResendVerificationForm.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useCallback, useEffect, useId, useState } from "react";
+import { useI18n } from "../lang/I18nProvider";
 
 type ResendVerificationFormProps = {
   initialEmail?: string;
@@ -11,6 +12,7 @@ export default function ResendVerificationForm({ initialEmail = "", className }:
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const inputId = useId();
+  const { t } = useI18n();
 
   useEffect(() => {
     setEmail(initialEmail);
@@ -33,33 +35,33 @@ export default function ResendVerificationForm({ initialEmail = "", className }:
         });
         const payload = await response.json().catch(() => null);
         if (!response.ok) {
-          const message =
-            (payload && typeof payload === "object" && typeof (payload as Record<string, unknown>).error === "string"
-              ? ((payload as Record<string, unknown>).error as string)
-              : null) || "Nie udało się wysłać wiadomości. Spróbuj ponownie.";
+        const message =
+          (payload && typeof payload === "object" && typeof (payload as Record<string, unknown>).error === "string"
+            ? ((payload as Record<string, unknown>).error as string)
+            : null) || t("auth.errors.resend");
           throw new Error(message);
         }
         const message =
           payload && typeof payload === "object" && typeof (payload as Record<string, unknown>).message === "string"
             ? ((payload as Record<string, unknown>).message as string)
-            : "Wysłaliśmy nowy link weryfikacyjny.";
+            : t("auth.messages.resendSuccess");
         setSuccess(message);
       } catch (err) {
         console.error("resend verification", err);
-        const message = err instanceof Error ? err.message : "Nie udało się wysłać wiadomości.";
+        const message = err instanceof Error ? err.message : t("auth.errors.resendGeneric");
         setError(message);
       } finally {
         setIsSubmitting(false);
       }
     },
-    [email]
+    [email, t]
   );
 
   return (
     <form onSubmit={handleSubmit} className={className ?? "space-y-3"}>
       <div className="space-y-2">
         <label className="block text-sm font-medium text-slate-200" htmlFor={inputId}>
-          Adres e-mail
+          {t("common.labels.email")}
         </label>
         <input
           id={inputId}
@@ -67,12 +69,12 @@ export default function ResendVerificationForm({ initialEmail = "", className }:
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           className="w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
-          placeholder="adres@email.pl"
+          placeholder={t("common.placeholders.email")}
           required
           disabled={isSubmitting}
           autoComplete="email"
         />
-        <p className="text-xs text-slate-400">Wpisz swój adres, aby otrzymać nowy link weryfikacyjny.</p>
+        <p className="text-xs text-slate-400">{t("auth.messages.verificationEmailInfo")}</p>
       </div>
       {error && (
         <p role="alert" className="text-sm text-rose-400">
@@ -90,7 +92,7 @@ export default function ResendVerificationForm({ initialEmail = "", className }:
           className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
           disabled={isSubmitting}
         >
-          {isSubmitting ? "Wysyłanie..." : "Wyślij ponownie"}
+          {isSubmitting ? t("resend.submitting") : t("resend.submit")}
         </button>
       </div>
     </form>

--- a/frontend/src/components/TermsFooter.tsx
+++ b/frontend/src/components/TermsFooter.tsx
@@ -1,15 +1,14 @@
 import { Link } from "react-router-dom";
+import { useI18n } from "../lang/I18nProvider";
 
 export default function TermsFooter() {
+  const { t } = useI18n();
   return (
     <footer className="mt-auto bg-slate-900/80 py-4 text-center text-xs text-slate-400">
       <div className="container mx-auto flex flex-col items-center justify-center gap-1 px-4 sm:flex-row">
-        <span>Korzystanie z serwisu oznacza akceptację regulaminu.</span>
-        <Link
-          to="/terms"
-          className="font-semibold text-blue-300 transition hover:text-blue-200"
-        >
-          Przeczytaj regulamin
+        <span>{t("termsFooter.disclaimer")}</span>
+        <Link to="/terms" className="font-semibold text-blue-300 transition hover:text-blue-200">
+          {t("termsFooter.cta")}
         </Link>
       </div>
     </footer>

--- a/frontend/src/components/TermsPage.tsx
+++ b/frontend/src/components/TermsPage.tsx
@@ -1,174 +1,48 @@
+import { useI18n } from "../lang/I18nProvider";
+
 export default function TermsPage() {
+  const { t, dictionary } = useI18n();
+  const terms = (dictionary.terms as Record<string, unknown>) ?? {};
+  const sections = Array.isArray(terms.sections)
+    ? (terms.sections as Array<{ title?: unknown; paragraphs?: unknown; list?: unknown }>)
+    : [];
+
   return (
     <div className="bg-slate-950 text-slate-100">
       <div className="mx-auto max-w-4xl px-6 py-12">
         <header className="mb-10">
-          <h1 className="text-4xl font-bold text-blue-300">Regulamin serwisu KupPixel</h1>
-          <p className="mt-4 text-sm text-slate-300">
-            Niniejszy regulamin określa zasady korzystania z serwisu KupPixel, w tym warunki
-            świadczenia usług drogą elektroniczną, zasady odpowiedzialności oraz tryb składania
-            reklamacji. Korzystając z serwisu, akceptujesz postanowienia poniższego dokumentu.
-          </p>
+          <h1 className="text-4xl font-bold text-blue-300">{t("terms.title")}</h1>
+          <p className="mt-4 text-sm text-slate-300">{t("terms.intro")}</p>
         </header>
 
         <section className="space-y-4">
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">1. Postanowienia ogólne</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              1.1. Administratorem serwisu jest KupPixel Sp. z o.o. z siedzibą w Warszawie.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              1.2. Regulamin określa zasady korzystania z usług dostępnych za pośrednictwem
-              serwisu internetowego KupPixel, w szczególności zasady rejestracji, nabywania pól
-              pikselowych oraz publikowania treści.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              1.3. Korzystanie z serwisu wymaga akceptacji regulaminu oraz posiadania aktywnego
-              konta użytkownika.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">2. Rejestracja i konto użytkownika</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              2.1. Rejestracja konta jest dobrowolna i odbywa się poprzez wypełnienie formularza
-              rejestracyjnego oraz potwierdzenie adresu e-mail.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              2.2. Użytkownik zobowiązany jest do podania prawdziwych danych oraz aktualizacji
-              ich w razie zmian. Administrator nie ponosi odpowiedzialności za skutki podania
-              błędnych danych kontaktowych.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              2.3. Użytkownik jest zobowiązany do ochrony danych logowania przed osobami trzecimi.
-              Wszelkie czynności dokonane po zalogowaniu uważa się za działania użytkownika.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">3. Zakup i zarządzanie pikselami</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              3.1. Użytkownik może nabywać piksele zgodnie z obowiązującym cennikiem, wyrażonym w
-              punktach lub innych jednostkach wskazanych w serwisie.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              3.2. Po nabyciu pikseli użytkownik może umieszczać na nich grafiki, linki oraz teksty,
-              o ile nie naruszają one prawa, dobrych obyczajów ani praw osób trzecich.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              3.3. Administrator zastrzega sobie prawo do odmowy publikacji lub usunięcia treści,
-              które naruszają regulamin lub powszechnie obowiązujące przepisy. W takim przypadku
-              użytkownikowi nie przysługuje zwrot poniesionych kosztów, jeżeli naruszenie wynikało z
-              jego zawinionego działania.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">4. Minimalna odpowiedzialność</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              4.1. Administrator ponosi odpowiedzialność wobec użytkownika jedynie w granicach
-              rzeczywistej szkody, będącej bezpośrednim i zawinionym następstwem niewykonania lub
-              nienależytego wykonania usługi. Odpowiedzialność za utracone korzyści jest wyłączona w
-              najszerszym dopuszczalnym przez prawo zakresie.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              4.2. Administrator nie odpowiada za szkody wynikłe z:
-            </p>
-            <ul className="ml-6 list-disc space-y-1 text-sm text-slate-200">
-              <li>działań lub zaniechań użytkownika lub osób trzecich,</li>
-              <li>zdarzeń siły wyższej, awarii sieci telekomunikacyjnych, serwerów lub oprogramowania,</li>
-              <li>zawieszenia lub zakończenia świadczenia usług wynikających z naruszenia regulaminu przez użytkownika.</li>
-            </ul>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">5. Brak gwarancji</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              5.1. Serwis KupPixel świadczony jest w stanie „takim, jaki jest”. Administrator nie
-              udziela żadnej gwarancji, w tym gwarancji przydatności do określonego celu, ciągłej
-              dostępności czy bezbłędnego działania serwisu.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              5.2. Administrator nie gwarantuje skuteczności działań marketingowych prowadzonych przez
-              użytkownika przy użyciu nabytych pikseli ani liczby odwiedzin generowanych przez linki.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">6. Prawo do zmian oferty</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              6.1. Administrator zastrzega sobie prawo do wprowadzania zmian w ofercie serwisu, w tym
-              modyfikacji funkcjonalności, cennika, zasad przyznawania punktów oraz warunków promocji.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              6.2. Zmiany wchodzą w życie w terminie wskazanym w ogłoszeniu zamieszczonym na stronie
-              głównej serwisu. Użytkownicy zostaną o nich poinformowani co najmniej 7 dni wcześniej,
-              chyba że zmiana wynika z nagłej potrzeby zapewnienia bezpieczeństwa serwisu.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              6.3. Kontynuowanie korzystania z serwisu po wejściu w życie zmian oznacza ich akceptację.
-              W przypadku braku zgody użytkownik ma prawo do rozwiązania umowy ze skutkiem natychmiastowym.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">7. Prawa autorskie i treści użytkowników</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              7.1. Użytkownik publikujący treści w serwisie oświadcza, że posiada prawa do ich
-              rozpowszechniania lub uzyskał odpowiednie zgody.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              7.2. Użytkownik udziela administratorowi niewyłącznej licencji na publiczne wyświetlanie
-              oraz przechowywanie publikowanych materiałów w zakresie koniecznym do realizacji usług.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              7.3. Administrator może usuwać treści naruszające prawo lub regulamin, a także blokować
-              konta użytkowników dopuszczających się powtarzających naruszeń.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">8. Reklamacje</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              8.1. Reklamacje dotyczące funkcjonowania serwisu można składać drogą elektroniczną na adres
-              reklamacje@kuppixel.pl w terminie 30 dni od wystąpienia zdarzenia będącego podstawą reklamacji.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              8.2. Reklamacja powinna zawierać dane umożliwiające identyfikację użytkownika oraz opis zgłaszanych
-              zastrzeżeń. Administrator rozpatrzy zgłoszenie w terminie 14 dni roboczych od daty otrzymania.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              8.3. W przypadku braku możliwości rozpatrzenia reklamacji w podanym terminie, administrator poinformuje
-              użytkownika o przyczynach opóźnienia i wskaże przewidywany termin udzielenia odpowiedzi.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">9. Dane osobowe</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              9.1. Administratorem danych osobowych użytkowników jest KupPixel Sp. z o.o. Dane przetwarzane są w
-              celu realizacji usług elektronicznych i obsługi kont użytkownika zgodnie z polityką prywatności.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              9.2. Użytkownikowi przysługuje prawo dostępu do treści swoich danych oraz ich poprawiania, ograniczenia
-              przetwarzania, przenoszenia i usunięcia na zasadach określonych w obowiązujących przepisach.
-            </p>
-          </div>
-
-          <div>
-            <h2 className="text-2xl font-semibold text-blue-200">10. Postanowienia końcowe</h2>
-            <p className="mt-2 text-sm leading-relaxed text-slate-200">
-              10.1. W sprawach nieuregulowanych regulaminem zastosowanie mają przepisy prawa polskiego, w szczególności
-              ustawy o świadczeniu usług drogą elektroniczną oraz Kodeksu cywilnego.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              10.2. Spory wynikłe z korzystania z serwisu rozstrzygane będą przez właściwe sądy powszechne. Użytkownik
-              będący konsumentem może skorzystać z pozasądowych sposobów rozpatrywania sporów i dochodzenia roszczeń.
-            </p>
-            <p className="text-sm leading-relaxed text-slate-200">
-              10.3. Regulamin wchodzi w życie z dniem jego publikacji na stronie serwisu.
-            </p>
-          </div>
+          {sections.map((section, index) => {
+            const title = typeof section.title === "string" ? section.title : undefined;
+            const paragraphs = Array.isArray(section.paragraphs)
+              ? (section.paragraphs as string[])
+              : [];
+            const listItems = Array.isArray(section.list) ? (section.list as string[]) : [];
+            return (
+              <div key={title ?? `section-${index}`}>
+                {title && <h2 className="text-2xl font-semibold text-blue-200">{title}</h2>}
+                {paragraphs.map((paragraph, paragraphIndex) => (
+                  <p
+                    key={`paragraph-${paragraphIndex}`}
+                    className={`text-sm leading-relaxed text-slate-200${paragraphIndex === 0 ? " mt-2" : ""}`}
+                  >
+                    {paragraph}
+                  </p>
+                ))}
+                {listItems.length > 0 && (
+                  <ul className="ml-6 list-disc space-y-1 text-sm text-slate-200">
+                    {listItems.map((item, listIndex) => (
+                      <li key={`list-${listIndex}`}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
         </section>
       </div>
     </div>

--- a/frontend/src/lang/I18nProvider.tsx
+++ b/frontend/src/lang/I18nProvider.tsx
@@ -1,0 +1,124 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { LANGUAGE_STORAGE_KEY, LanguageCode, LanguageDefinition, TranslationDictionary, defaultLanguage, languages } from "./index";
+
+type TranslationParams = Record<string, string | number>;
+
+type I18nContextValue = {
+  language: LanguageCode;
+  setLanguage: (code: LanguageCode) => void;
+  availableLanguages: LanguageDefinition[];
+  t: (key: string, params?: TranslationParams) => string;
+  dictionary: TranslationDictionary;
+};
+
+type TranslationValue = string | TranslationDictionary | TranslationValue[];
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+const placeholderPattern = /\{\{\s*(\w+)\s*\}\}/g;
+
+function resolveTranslation(dictionary: TranslationDictionary, key: string): string | undefined {
+  const segments = key.split(".");
+  let current: TranslationDictionary | TranslationValue | undefined = dictionary;
+  for (const segment of segments) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    const next = (current as TranslationDictionary)[segment];
+    if (next === undefined) {
+      return undefined;
+    }
+    current = next;
+  }
+  if (typeof current === "string") {
+    return current;
+  }
+  return undefined;
+}
+
+function formatTranslation(template: string, params?: TranslationParams): string {
+  if (!params) {
+    return template;
+  }
+  return template.replace(placeholderPattern, (match, token: string) => {
+    if (Object.prototype.hasOwnProperty.call(params, token)) {
+      return String(params[token]);
+    }
+    return match;
+  });
+}
+
+function isLanguageCode(value: string | null): value is LanguageCode {
+  return value === "pl" || value === "en";
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<LanguageCode>(() => {
+    if (typeof window === "undefined") {
+      return defaultLanguage;
+    }
+    const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    if (isLanguageCode(stored)) {
+      return stored;
+    }
+    return defaultLanguage;
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+    }
+  }, [language]);
+
+  const availableLanguages = useMemo(() => Object.values(languages), []);
+
+  const dictionary = useMemo(() => languages[language]?.dictionary ?? languages[defaultLanguage].dictionary, [language]);
+  const fallbackDictionary = useMemo(
+    () => (language === defaultLanguage ? dictionary : languages[defaultLanguage].dictionary),
+    [dictionary, language]
+  );
+
+  const translate = useCallback(
+    (key: string, params?: TranslationParams) => {
+      const primary = resolveTranslation(dictionary, key);
+      if (primary) {
+        return formatTranslation(primary, params);
+      }
+      const fallback = resolveTranslation(fallbackDictionary, key);
+      if (fallback) {
+        return formatTranslation(fallback, params);
+      }
+      return key;
+    },
+    [dictionary, fallbackDictionary]
+  );
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      language,
+      setLanguage,
+      availableLanguages,
+      t: translate,
+      dictionary,
+    }),
+    [availableLanguages, dictionary, language, translate]
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error("useI18n must be used within an I18nProvider");
+  }
+  return context;
+}

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -1,0 +1,346 @@
+{
+  "common": {
+    "appName": "Kup Pixel",
+    "languageLabel": "Language",
+    "actions": {
+      "activate": "Activate",
+      "activateCode": "Redeem code",
+      "cancel": "Cancel",
+      "close": "Close",
+      "editUrl": "Edit URL",
+      "goBack": "← Back to the board",
+      "goHome": "Back to home",
+      "login": "Log in",
+      "loginCta": "Sign in",
+      "logout": "Log out",
+      "openLogin": "Go to login",
+      "openRegister": "Create account",
+      "readTerms": "Read the terms",
+      "refresh": "Refresh data",
+      "register": "Register",
+      "resend": "Send again",
+      "save": "Save",
+      "simulatePurchase": "Simulate purchase",
+      "submit": "Submit"
+    },
+    "labels": {
+      "email": "Email address",
+      "password": "Password",
+      "pixelColor": "Pixel color",
+      "pixelUrl": "Ad URL",
+      "activationCode": "Activation code",
+      "balance": "Balance",
+      "pixelCost": "Pixel cost"
+    },
+    "placeholders": {
+      "pixelUrl": "https://your-domain.com",
+      "email": "address@email.com",
+      "activationCode": "XXXX-XXXX-XXXX-XXXX"
+    },
+    "status": {
+      "loading": "Loading...",
+      "processing": "Processing payment...",
+      "sending": "Sending..."
+    },
+    "units": {
+      "points": "{{count}} points",
+      "pointsShort": "pts"
+    }
+  },
+  "navigation": {
+    "home": "Home",
+    "account": "Your account",
+    "activateCode": "Redeem code",
+    "balance": "Balance: {{points}} pts",
+    "pixelCost": "Pixel cost: {{points}} pts",
+    "loginPrompt": "Sign in to get started."
+  },
+  "auth": {
+    "errors": {
+      "refresh": "Failed to refresh the session ({{status}})",
+      "parseUser": "Could not read account details.",
+      "login": "Failed to sign in. Please try again.",
+      "register": "Failed to create the account. Please try again.",
+      "logout": "Failed to reserve the pixel. Please try again.",
+      "purchase": "Unable to reserve any of the selected pixels. Please try again.",
+      "fetchPixels": "Failed to fetch pixel board.",
+      "account": "An error occurred while loading the account.",
+      "savePixel": "Failed to save changes.",
+      "activateCode": "Failed to redeem the code.",
+      "resend": "Failed to send the message. Please try again.",
+      "resendGeneric": "Failed to send the message.",
+      "verify": "Could not confirm the email address.",
+      "verifyMissingToken": "Verification token is missing from the URL.",
+      "verifyUnexpected": "An unexpected error occurred. Please try again later.",
+      "api": "API error: {{status}}",
+      "requiresLogin": "Sign in to continue.",
+      "insufficientPoints": "Not enough points to buy a pixel. Redeem a code and try again.",
+      "invalidUrl": "The URL must include a valid scheme (e.g. https://).",
+      "missingUrl": "Enter a valid URL.",
+      "missingColor": "This pixel has no color assigned and cannot be updated.",
+      "activationFormat": "The code must follow XXXX-XXXX-XXXX-XXXX and contain only letters or digits.",
+      "sessionExpired": "Your session expired. Please sign in again.",
+      "sessionExpiredLong": "Your session expired. Sign in again and try once more.",
+      "loginRequired": "Sign in to view the pixel board.",
+      "loginToView": "Sign in to view your account details.",
+      "loginToViewPixels": "Sign in again to view your pixels.",
+      "loginToUpdate": "Sign in to update the ad URL.",
+      "loginToBuy": "Sign in to buy this pixel.",
+      "loginToBuyMany": "Sign in to buy the selected pixels.",
+      "loginToProceed": "Sign in to buy the selected pixels.",
+      "loginToStart": "Sign in to get started.",
+      "loginToFinish": "Sign in again to finish the purchase.",
+      "selectionRequired": "Select at least one pixel to continue."
+    },
+    "messages": {
+      "registerSuccess": "Account created. Check your inbox.",
+      "loginModalDefault": "Enter your credentials to continue.",
+      "activationInfo": "Redeem a code to receive points and buy pixels.",
+      "activationCost": "One pixel costs {{points}} points.",
+      "activationSuccess": "Code redeemed successfully.",
+      "activationSuccessWithPoints": "Code redeemed! Added {{added}} points{{suffix}}",
+      "activationSuffix": " (total {{total}} pts).",
+      "resendPrompt": "Didn't receive the email? Send a new verification link.",
+      "resendSuccess": "We have sent a new verification link.",
+      "verifySuccess": "Email address confirmed. You can sign in now.",
+      "verifyLoading": "Verifying the token...",
+      "verificationEmailInfo": "Enter your email address to receive a new verification link.",
+      "simulationProcessing": "Virtual payment confirmation in progress. This will only take a moment...",
+      "simulationInfo": "The simulation does not charge real money – it's only a preview of the future flow.",
+      "simulationPartial": "Some pixels could not be reserved. Check the details below.",
+      "accountUpdated": "Ad URL has been updated.",
+      "registerTermsError": "Accept the terms to create an account.",
+      "registerInfo": "Enter your email and password to create an account and start playing with the board.",
+      "registerEmailInfo": "We have sent you an email with an activation link. Click it to finish registration.",
+      "registerHelp": "Can't find the email? Check spam or wait a few minutes. You can also resend the link below.",
+      "accountBalanceHint": "Redeem codes to earn more points and claim additional pixels.",
+      "accountPixelCostHint": "You need at least this many points to claim a new pixel.",
+      "accountManageHint": "Redeem a code or refresh the data to view the current balance.",
+      "accountNoPixels": "You have not purchased any pixels yet.",
+      "accountLoading": "Loading account data...",
+      "accountPixels": "Purchased pixels",
+      "accountLoggedInAs": "Signed in as {{email}}",
+      "accountIntro": "Manage your purchased pixels and update ad destinations.",
+      "loginPrompt": "Enter your credentials to continue.",
+      "verifyResendTitle": "Send the link again",
+      "verifyResendDescription": "Enter your email address to receive a new verification token.",
+      "verifyErrorTitle": "Could not verify the account",
+      "verifyReady": "All set!"
+    }
+  },
+  "landing": {
+    "title": "Kup Pixel",
+    "subtitle": "Pick your pixel on a 1000×1000 digital board and leave your mark.",
+    "stats": {
+      "taken": "Taken: {{count}}",
+      "free": "Free: {{count}}"
+    },
+    "balance": {
+      "label": "Balance: {{points}} pts",
+      "pixelCost": "Pixel cost: {{points}} pts",
+      "missing": "Check configuration",
+      "loggedOut": "Sign in"
+    },
+    "loading": "Loading the pixel grid...",
+    "instructionsTitle": "How to use the board:",
+    "instructions": {
+      "single": "Click a single pixel to edit it or open the owner's ad link.",
+      "multi": "Drag with the left mouse button to select a block of free pixels and buy them together.",
+      "pan": "Hold {{ctrl}} or {{shift}} while dragging to smoothly pan across the board.",
+      "zoom": "Zooming in reveals a helper grid that makes counting and precise positioning easier."
+    },
+    "selection": "Selected {{count}} free pixels. Finish the purchase on the form page to reserve them all.",
+    "tips": "The tips above will help you navigate quickly — from single clicks through selecting areas to smooth panning and precise work when zoomed in.",
+    "linkOpen": "Open in a new tab"
+  },
+  "buy": {
+    "titleSingle": "Buy this pixel",
+    "titleMultiple": "Buy selected pixels",
+    "descriptionSingle": "You picked pixel ID {{id}}. Choose a color and go through the mock checkout to see how the real flow will behave.",
+    "descriptionMultiple": "You picked {{count}} free pixels with IDs: {{ids}}. Choose a color and go through the mock checkout to see how the real flow will behave.",
+    "unknownPixel": "unknown",
+    "costTitle": "Purchase cost",
+    "balanceTitle": "Your balance",
+    "configure": "Check configuration",
+    "balanceLogin": "Sign in",
+    "matchTitle": "Customize your pixel",
+    "matchDescription": "Pick a color that represents your brand – the preview and HEX value update automatically.",
+    "colorPreviewLabel": "Color preview",
+    "urlHint": "Visitors will be redirected to this address when they click the pixel.",
+    "simulateSingle": "Simulate purchase",
+    "simulateMultiple": "Simulate purchase of {{count}} pixels",
+    "costBreakdown": "{{count}} × {{price}} {{unit}} = {{total}} points",
+    "singlePrice": "{{price}} {{unit}}",
+    "successTitle": "Success!",
+    "successDescriptionSingle": "Pixel #{{id}} has been reserved with color {{color}}.",
+    "successDescriptionMultiple": "All {{count}} pixels have been reserved with color {{color}}.",
+    "successPreview": "Preview:",
+    "successMockInfo": "This is still a mock payment – the production flow will include a real checkout and customer confirmations.",
+    "partialTitle": "Partial success",
+    "partialDescription": "Some pixels were purchased, but a few need another attempt. Review the details above and try again after resolving the issues.",
+    "resultsTitle": "Purchase results",
+    "resultStatus": {
+      "taken": "Purchased"
+    },
+    "return": "Back to the board"
+  },
+  "pixelCanvas": {
+    "selection": "Selected {{count}} free pixels"
+  },
+  "account": {
+    "title": "Your account",
+    "saldoTitle": "Point balance",
+    "pixelCostTitle": "Pixel price",
+    "manageTitle": "Manage balance",
+    "activate": "Redeem code",
+    "refresh": "Refresh data",
+    "noData": "No data",
+    "table": {
+      "id": "ID",
+      "position": "Position",
+      "color": "Color",
+      "url": "URL",
+      "updatedAt": "Last updated",
+      "actions": "Actions",
+      "noUrl": "None",
+      "coordinates": "x: {{x}}, y: {{y}}"
+    },
+    "modal": {
+      "title": "Redeem a point code",
+      "currentBalance": "Current balance: {{points}} pts"
+    }
+  },
+  "activationModal": {
+    "title": "Redeem a point code",
+    "info": "Redeem a code to receive points and buy pixels.",
+    "currentBalance": "Current balance: {{points}} pts",
+    "error": "Failed to redeem the code.",
+    "submit": "Redeem",
+    "submitting": "Redeeming..."
+  },
+  "loginModal": {
+    "title": "Sign in",
+    "close": "Close",
+    "cancel": "Cancel",
+    "submit": "Log in",
+    "submitting": "Signing in..."
+  },
+  "registerModal": {
+    "title": "Create account",
+    "successTitle": "Confirm your email",
+    "terms": "I accept the service {{termsLink}}.",
+    "termsLink": "Terms of Use",
+    "loginCta": "Already have an account? Sign in",
+    "submit": "Register",
+    "submitting": "Creating..."
+  },
+  "resend": {
+    "title": "Email address",
+    "hint": "Enter your address to receive a new verification link.",
+    "submit": "Send again",
+    "submitting": "Sending..."
+  },
+  "verify": {
+    "title": "Email verification",
+    "loading": "Verifying the token...",
+    "success": "Email address confirmed. You can sign in now.",
+    "goToLogin": "Go to login",
+    "goHome": "Back to home"
+  },
+  "notFound": {
+    "title": "Oops! Page not found.",
+    "cta": "Back to the pixel board"
+  },
+  "termsFooter": {
+    "disclaimer": "Using the service means you accept the terms.",
+    "cta": "Read the terms"
+  },
+  "terms": {
+    "title": "KupPixel Terms of Service",
+    "intro": "These terms describe how KupPixel works, including service scope, responsibilities and the complaint procedure. By using the service you accept the provisions below.",
+    "sections": [
+      {
+        "title": "1. General provisions",
+        "paragraphs": [
+          "1.1. KupPixel Sp. z o.o. based in Warsaw operates the service.",
+          "1.2. The terms define how to use KupPixel, including registration, purchasing pixel slots and publishing content.",
+          "1.3. Using the service requires accepting the terms and having an active user account."
+        ]
+      },
+      {
+        "title": "2. Registration and account",
+        "paragraphs": [
+          "2.1. Registration is voluntary and requires completing the form and confirming your email address.",
+          "2.2. Users must provide accurate data and keep it up to date. The operator is not responsible for issues caused by incorrect contact details.",
+          "2.3. Users must protect their login credentials. All actions taken after signing in are treated as the user's actions."
+        ]
+      },
+      {
+        "title": "3. Buying and managing pixels",
+        "paragraphs": [
+          "3.1. Pixels can be purchased according to the current price list expressed in points or other units shown in the service.",
+          "3.2. After purchasing, the user may add graphics, links or text as long as it does not violate law, good manners or third-party rights.",
+          "3.3. The operator may refuse to publish or remove content that breaks the rules or law. In such cases no refund is granted if the breach was caused by the user."
+        ]
+      },
+      {
+        "title": "4. Limited liability",
+        "paragraphs": [
+          "4.1. The operator is liable only for direct damage caused by intentional or negligent failure to provide the service. Liability for lost profits is excluded as far as permitted by law.",
+          "4.2. The operator is not liable for damage resulting from:"
+        ],
+        "list": [
+          "actions or omissions of the user or third parties,",
+          "force majeure, failures of networks, servers or software,",
+          "suspension or termination of services due to a breach of the terms by the user."
+        ]
+      },
+      {
+        "title": "5. No warranty",
+        "paragraphs": [
+          "5.1. KupPixel is provided “as is”. The operator gives no warranty, including fitness for a particular purpose, availability or error-free operation.",
+          "5.2. The operator does not guarantee the effectiveness of marketing activities or the number of visits generated by purchased pixels."
+        ]
+      },
+      {
+        "title": "6. Right to modify the offer",
+        "paragraphs": [
+          "6.1. The operator may change the service, including functionality, pricing, point rules and promotions.",
+          "6.2. Changes take effect on the date announced on the homepage. Users will be informed at least 7 days in advance unless security requires immediate action.",
+          "6.3. Continuing to use the service after changes take effect means you accept them. If you disagree you may terminate the agreement immediately."
+        ]
+      },
+      {
+        "title": "7. Copyright and user content",
+        "paragraphs": [
+          "7.1. By publishing content you confirm that you hold the rights or have obtained consent to share it.",
+          "7.2. You grant the operator a non-exclusive licence to display and store the materials as required to provide the service.",
+          "7.3. The operator may remove content that violates the law or the terms and may block accounts of repeat offenders."
+        ]
+      },
+      {
+        "title": "8. Complaints",
+        "paragraphs": [
+          "8.1. Complaints about the service can be sent to reklamacje@kuppixel.pl within 30 days of the issue.",
+          "8.2. The complaint must include identification details and a description of the issue. The operator will respond within 14 working days.",
+          "8.3. If more time is needed the operator will inform the user about the delay and provide an estimated response date."
+        ]
+      },
+      {
+        "title": "9. Personal data",
+        "paragraphs": [
+          "9.1. KupPixel Sp. z o.o. is the data controller. Data is processed to provide electronic services and manage user accounts in line with the privacy policy.",
+          "9.2. Users have the right to access, rectify, restrict, transfer or delete their data as allowed by law."
+        ]
+      },
+      {
+        "title": "10. Final provisions",
+        "paragraphs": [
+          "10.1. Polish law applies to matters not covered by the terms, especially the Act on Electronic Services and the Civil Code.",
+          "10.2. Disputes will be resolved by competent courts. Consumers may use out-of-court dispute resolution methods.",
+          "10.3. The terms take effect on the date they are published on the website."
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/src/lang/index.ts
+++ b/frontend/src/lang/index.ts
@@ -1,0 +1,24 @@
+import en from "./en.json";
+import pl from "./pl.json";
+
+export type TranslationValue = string | TranslationDictionary | TranslationValue[];
+export type TranslationDictionary = { [key: string]: TranslationValue };
+
+export type LanguageCode = "pl" | "en";
+
+export type LanguageDefinition = {
+  code: LanguageCode;
+  label: string;
+  dictionary: TranslationDictionary;
+};
+
+const castDictionary = (value: unknown): TranslationDictionary => value as TranslationDictionary;
+
+export const languages: Record<LanguageCode, LanguageDefinition> = {
+  pl: { code: "pl", label: "Polski", dictionary: castDictionary(pl) },
+  en: { code: "en", label: "English", dictionary: castDictionary(en) },
+};
+
+export const defaultLanguage: LanguageCode = "pl";
+
+export const LANGUAGE_STORAGE_KEY = "kuppixel.language";

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -1,0 +1,346 @@
+{
+  "common": {
+    "appName": "Kup Piksel",
+    "languageLabel": "Język",
+    "actions": {
+      "activate": "Aktywuj",
+      "activateCode": "Aktywuj kod",
+      "cancel": "Anuluj",
+      "close": "Zamknij",
+      "editUrl": "Zmień URL",
+      "goBack": "← Wróć na tablicę",
+      "goHome": "Wróć na stronę główną",
+      "login": "Zaloguj",
+      "loginCta": "Zaloguj się",
+      "logout": "Wyloguj",
+      "openLogin": "Przejdź do logowania",
+      "openRegister": "Załóż konto",
+      "readTerms": "Przeczytaj regulamin",
+      "refresh": "Odśwież dane",
+      "register": "Zarejestruj się",
+      "resend": "Wyślij ponownie",
+      "save": "Zapisz",
+      "simulatePurchase": "Zasymuluj zakup",
+      "submit": "Wyślij"
+    },
+    "labels": {
+      "email": "Adres e-mail",
+      "password": "Hasło",
+    "pixelColor": "Kolor piksela",
+    "pixelUrl": "Adres URL reklamy",
+    "activationCode": "Kod aktywacyjny",
+      "balance": "Saldo",
+      "pixelCost": "Koszt piksela"
+    },
+    "placeholders": {
+      "pixelUrl": "https://twoja-domena.pl",
+      "email": "adres@email.pl",
+      "activationCode": "XXXX-XXXX-XXXX-XXXX"
+    },
+    "status": {
+      "loading": "Ładuję...",
+      "processing": "Przetwarzanie płatności...",
+      "sending": "Wysyłanie..."
+    },
+    "units": {
+      "points": "{{count}} punktów",
+      "pointsShort": "pkt"
+    }
+  },
+  "navigation": {
+    "home": "Home",
+    "account": "Twoje konto",
+    "activateCode": "Aktywuj kod",
+    "balance": "Saldo: {{points}} pkt",
+    "pixelCost": "Koszt piksela: {{points}} pkt",
+    "loginPrompt": "Zaloguj się, aby rozpocząć."
+  },
+  "auth": {
+    "errors": {
+      "refresh": "Nie udało się odświeżyć sesji ({{status}})",
+      "parseUser": "Nie udało się odczytać informacji o koncie.",
+      "login": "Nie udało się zalogować. Spróbuj ponownie.",
+      "register": "Nie udało się utworzyć konta. Spróbuj ponownie.",
+      "logout": "Nie udało się zarezerwować piksela. Spróbuj ponownie.",
+      "purchase": "Nie udało się zarezerwować żadnego z zaznaczonych pikseli. Spróbuj ponownie.",
+      "fetchPixels": "Nie udało się pobrać stanu pikseli.",
+      "account": "Wystąpił błąd podczas pobierania danych konta.",
+      "savePixel": "Nie udało się zapisać zmian.",
+      "activateCode": "Nie udało się aktywować kodu.",
+      "resend": "Nie udało się wysłać wiadomości. Spróbuj ponownie.",
+      "resendGeneric": "Nie udało się wysłać wiadomości.",
+      "verify": "Nie udało się potwierdzić adresu e-mail.",
+      "verifyMissingToken": "Brakuje tokenu weryfikacyjnego w adresie URL.",
+      "verifyUnexpected": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie później.",
+      "api": "Błąd API: {{status}}",
+      "requiresLogin": "Aby kontynuować, zaloguj się.",
+      "insufficientPoints": "Brak wystarczającej liczby punktów, aby kupić piksel. Aktywuj kod i spróbuj ponownie.",
+      "invalidUrl": "Adres URL musi zawierać poprawny schemat (np. https://).",
+      "missingUrl": "Podaj poprawny adres URL.",
+      "missingColor": "Ten piksel nie ma przypisanego koloru i nie może zostać zaktualizowany.",
+      "activationFormat": "Kod musi mieć format XXXX-XXXX-XXXX-XXXX i składać się z cyfr lub liter.",
+      "sessionExpired": "Twoja sesja wygasła. Zaloguj się ponownie.",
+      "sessionExpiredLong": "Twoja sesja wygasła. Zaloguj się ponownie i spróbuj jeszcze raz.",
+      "loginRequired": "Aby zobaczyć tablicę pikseli, zaloguj się.",
+      "loginToView": "Zaloguj się, aby zobaczyć dane swojego konta.",
+      "loginToViewPixels": "Zaloguj się ponownie, aby zobaczyć swoje piksele.",
+      "loginToUpdate": "Zaloguj się, aby zaktualizować adres reklamy.",
+      "loginToBuy": "Zaloguj się, aby kupić wybrany piksel.",
+      "loginToBuyMany": "Zaloguj się, aby kupić zaznaczone piksele.",
+      "loginToProceed": "Zaloguj się, aby kupić zaznaczone piksele.",
+      "loginToStart": "Zaloguj się, aby rozpocząć.",
+      "loginToFinish": "Zaloguj się ponownie, aby sfinalizować zakup.",
+      "selectionRequired": "Wybierz co najmniej jeden piksel, aby kontynuować."
+    },
+    "messages": {
+      "registerSuccess": "Konto zostało utworzone. Sprawdź skrzynkę e-mail.",
+      "loginModalDefault": "Podaj dane logowania, aby kontynuować.",
+      "activationInfo": "Aktywuj kod, aby otrzymać punkty i kupować piksele.",
+      "activationCost": "Koszt jednego piksela to {{points}} punktów.",
+      "activationSuccess": "Kod został aktywowany.",
+      "activationSuccessWithPoints": "Kod aktywowany! Dodano {{added}} punktów{{suffix}}",
+      "activationSuffix": " (razem {{total}} pkt).",
+      "resendPrompt": "Nie otrzymałeś wiadomości? Wyślij ponownie link weryfikacyjny.",
+      "resendSuccess": "Wysłaliśmy nowy link weryfikacyjny.",
+      "verifySuccess": "Adres e-mail został potwierdzony. Możesz się teraz zalogować.",
+      "verifyLoading": "Trwa potwierdzanie tokenu weryfikacyjnego...",
+      "verificationEmailInfo": "Wpisz swój adres, aby otrzymać nowy link weryfikacyjny.",
+      "simulationProcessing": "Trwa wirtualne potwierdzanie płatności. To potrwa tylko chwilkę...",
+      "simulationInfo": "Symulacja nie pobiera prawdziwych środków – to jedynie podgląd przyszłego doświadczenia.",
+      "simulationPartial": "Nie wszystkie piksele udało się kupić. Sprawdź szczegóły poniżej.",
+      "accountUpdated": "Adres reklamy został zaktualizowany.",
+      "registerTermsError": "Aby utworzyć konto, zaakceptuj regulamin.",
+      "registerInfo": "Podaj adres e-mail i hasło, aby utworzyć konto i rozpocząć zabawę z tablicą pikseli.",
+      "registerEmailInfo": "Wysłaliśmy do Ciebie wiadomość z linkiem aktywacyjnym. Kliknij go, aby dokończyć rejestrację.",
+      "registerHelp": "Nie widzisz wiadomości? Sprawdź folder spam lub poczekaj kilka minut. Możesz też wysłać link ponownie poniżej.",
+      "accountBalanceHint": "Aktywuj kody, aby zdobyć więcej punktów i zajmować kolejne piksele.",
+      "accountPixelCostHint": "Do zajęcia nowego piksela potrzebujesz co najmniej tylu punktów.",
+      "accountManageHint": "Aktywuj kod lub odśwież dane, aby zobaczyć aktualne punkty.",
+      "accountNoPixels": "Nie masz jeszcze żadnych wykupionych pikseli.",
+      "accountLoading": "Ładuję dane konta...",
+      "accountPixels": "Wykupione piksele",
+      "accountLoggedInAs": "Zalogowano jako {{email}}",
+      "accountIntro": "Zarządzaj zakupionymi pikselami i aktualizuj adresy reklam.",
+      "loginPrompt": "Podaj dane logowania, aby kontynuować.",
+      "verifyResendTitle": "Wyślij link ponownie",
+      "verifyResendDescription": "Wpisz swój adres e-mail, aby otrzymać nowy token weryfikacyjny.",
+      "verifyErrorTitle": "Nie udało się potwierdzić konta",
+      "verifyReady": "Gotowe!"
+    }
+  },
+  "landing": {
+    "title": "Kup Piksel",
+    "subtitle": "Wybierz swój piksel na cyfrowej tablicy 1000×1000 i zostaw po sobie ślad.",
+    "stats": {
+      "taken": "Zajęte: {{count}}",
+      "free": "Wolne: {{count}}"
+    },
+    "balance": {
+      "label": "Saldo: {{points}} pkt",
+      "pixelCost": "Koszt piksela: {{points}} pkt",
+      "missing": "Sprawdź konfigurację",
+      "loggedOut": "Zaloguj się"
+    },
+    "loading": "Ładuję siatkę pikseli...",
+    "instructionsTitle": "Jak pracować z tablicą:",
+    "instructions": {
+      "single": "Kliknij pojedynczy piksel, aby przejść do edycji lub otworzyć link reklamowy właściciela.",
+      "multi": "Przeciągnij z wciśniętym lewym przyciskiem myszy, aby zaznaczyć blok wolnych pikseli do wspólnego zakupu.",
+      "pan": "Przytrzymaj {{ctrl}} lub {{shift}} i przeciągaj, aby płynnie przesuwać widok tablicy.",
+      "zoom": "Przy dużym powiększeniu pojawia się siatka pomocnicza, która ułatwia liczenie i precyzyjne ustawianie pikseli."
+    },
+    "selection": "Zaznaczono {{count}} wolnych pikseli. Dokończ zakup na stronie formularza, aby zarezerwować wszystkie.",
+    "tips": "Wskazówki powyżej pomogą Ci szybko odnaleźć się na tablicy — od pojedynczych kliknięć, przez zaznaczanie obszarów, po płynne przesuwanie i precyzyjną pracę na dużym powiększeniu.",
+    "linkOpen": "Otwórz w nowej karcie"
+  },
+  "buy": {
+    "titleSingle": "Kup ten piksel",
+    "titleMultiple": "Kup wybrane piksele",
+    "descriptionSingle": "Wybrałeś piksel o ID {{id}}. Tutaj możesz dobrać kolor i przejść przez fikcyjny proces płatności, aby zobaczyć, jak będzie działał prawdziwy checkout.",
+    "descriptionMultiple": "Wybrałeś {{count}} wolnych pikseli o ID: {{ids}}. Tutaj możesz dobrać kolor i przejść przez fikcyjny proces płatności, aby zobaczyć, jak będzie działał prawdziwy checkout.",
+    "unknownPixel": "nieznany",
+    "costTitle": "Koszt zakupu",
+    "balanceTitle": "Twoje saldo",
+    "configure": "Sprawdź konfigurację",
+    "balanceLogin": "Zaloguj się",
+    "matchTitle": "Dopasuj swój piksel",
+    "matchDescription": "Wybierz kolor, który najlepiej reprezentuje Twoją markę – podgląd i wartość HEX aktualizują się automatycznie.",
+    "colorPreviewLabel": "Podgląd koloru",
+    "urlHint": "Po kliknięciu w piksel użytkownik zostanie przekierowany pod ten adres.",
+    "simulateSingle": "Zasymuluj zakup",
+    "simulateMultiple": "Zasymuluj zakup {{count}} pikseli",
+    "costBreakdown": "{{count}} × {{price}} {{unit}} = {{total}} punktów",
+    "singlePrice": "{{price}} {{unit}}",
+    "successTitle": "Udało się!",
+    "successDescriptionSingle": "Piksel #{{id}} został zarezerwowany z kolorem {{color}}.",
+    "successDescriptionMultiple": "Wszystkie {{count}} piksele zostały zarezerwowane z kolorem {{color}}.",
+    "successPreview": "Podgląd:",
+    "successMockInfo": "To wciąż makieta płatności – w produkcji dodasz prawdziwy checkout oraz potwierdzenia dla klienta.",
+    "partialTitle": "Częściowy sukces",
+    "partialDescription": "Część pikseli została zakupiona, ale kilka wymaga ponownej próby. Sprawdź szczegóły powyżej i spróbuj ponownie po rozwiązaniu problemów.",
+    "resultsTitle": "Rezultaty zakupu",
+    "resultStatus": {
+      "taken": "Kupiono"
+    },
+    "return": "Wróć na tablicę"
+  },
+  "pixelCanvas": {
+    "selection": "{{count}} wolnych pikseli zaznaczonych"
+  },
+  "account": {
+    "title": "Twoje konto",
+    "saldoTitle": "Saldo punktów",
+    "pixelCostTitle": "Koszt jednego piksela",
+    "manageTitle": "Zarządzaj saldem",
+    "activate": "Aktywuj kod",
+    "refresh": "Odśwież dane",
+    "noData": "Brak danych",
+    "table": {
+      "id": "ID",
+      "position": "Pozycja",
+      "color": "Kolor",
+      "url": "Adres URL",
+      "updatedAt": "Ostatnia aktualizacja",
+      "actions": "Akcje",
+      "noUrl": "Brak",
+      "coordinates": "x: {{x}}, y: {{y}}"
+    },
+    "modal": {
+      "title": "Aktywuj kod punktowy",
+      "currentBalance": "Aktualne saldo: {{points}} pkt"
+    }
+  },
+  "activationModal": {
+    "title": "Aktywuj kod punktowy",
+    "info": "Aktywuj kod, aby otrzymać punkty i kupować piksele.",
+    "currentBalance": "Aktualne saldo: {{points}} pkt",
+    "error": "Nie udało się aktywować kodu.",
+    "submit": "Aktywuj",
+    "submitting": "Aktywuję..."
+  },
+  "loginModal": {
+    "title": "Zaloguj się",
+    "close": "Zamknij",
+    "cancel": "Anuluj",
+    "submit": "Zaloguj",
+    "submitting": "Logowanie..."
+  },
+  "registerModal": {
+    "title": "Załóż konto",
+    "successTitle": "Potwierdź adres e-mail",
+    "terms": "Akceptuję {{termsLink}} serwisu.",
+    "termsLink": "Regulamin",
+    "loginCta": "Masz już konto? Zaloguj się",
+    "submit": "Zarejestruj się",
+    "submitting": "Tworzenie..."
+  },
+  "resend": {
+    "title": "Adres e-mail",
+    "hint": "Wpisz swój adres, aby otrzymać nowy link weryfikacyjny.",
+    "submit": "Wyślij ponownie",
+    "submitting": "Wysyłanie..."
+  },
+  "verify": {
+    "title": "Potwierdzenie adresu e-mail",
+    "loading": "Trwa potwierdzanie tokenu weryfikacyjnego...",
+    "success": "Adres e-mail został potwierdzony. Możesz się teraz zalogować.",
+    "goToLogin": "Przejdź do logowania",
+    "goHome": "Wróć na stronę główną"
+  },
+  "notFound": {
+    "title": "Ups! Nie znaleziono strony.",
+    "cta": "Wróć na tablicę pikseli"
+  },
+  "termsFooter": {
+    "disclaimer": "Korzystanie z serwisu oznacza akceptację regulaminu.",
+    "cta": "Przeczytaj regulamin"
+  },
+  "terms": {
+    "title": "Regulamin serwisu KupPixel",
+    "intro": "Niniejszy regulamin określa zasady korzystania z serwisu KupPixel, w tym warunki świadczenia usług drogą elektroniczną, zasady odpowiedzialności oraz tryb składania reklamacji. Korzystając z serwisu, akceptujesz postanowienia poniższego dokumentu.",
+    "sections": [
+      {
+        "title": "1. Postanowienia ogólne",
+        "paragraphs": [
+          "1.1. Administratorem serwisu jest KupPixel Sp. z o.o. z siedzibą w Warszawie.",
+          "1.2. Regulamin określa zasady korzystania z usług dostępnych za pośrednictwem serwisu internetowego KupPixel, w szczególności zasady rejestracji, nabywania pól pikselowych oraz publikowania treści.",
+          "1.3. Korzystanie z serwisu wymaga akceptacji regulaminu oraz posiadania aktywnego konta użytkownika."
+        ]
+      },
+      {
+        "title": "2. Rejestracja i konto użytkownika",
+        "paragraphs": [
+          "2.1. Rejestracja konta jest dobrowolna i odbywa się poprzez wypełnienie formularza rejestracyjnego oraz potwierdzenie adresu e-mail.",
+          "2.2. Użytkownik zobowiązany jest do podania prawdziwych danych oraz aktualizacji ich w razie zmian. Administrator nie ponosi odpowiedzialności za skutki podania błędnych danych kontaktowych.",
+          "2.3. Użytkownik jest zobowiązany do ochrony danych logowania przed osobami trzecimi. Wszelkie czynności dokonane po zalogowaniu uważa się za działania użytkownika."
+        ]
+      },
+      {
+        "title": "3. Zakup i zarządzanie pikselami",
+        "paragraphs": [
+          "3.1. Użytkownik może nabywać piksele zgodnie z obowiązującym cennikiem, wyrażonym w punktach lub innych jednostkach wskazanych w serwisie.",
+          "3.2. Po nabyciu pikseli użytkownik może umieszczać na nich grafiki, linki oraz teksty, o ile nie naruszają one prawa, dobrych obyczajów ani praw osób trzecich.",
+          "3.3. Administrator zastrzega sobie prawo do odmowy publikacji lub usunięcia treści, które naruszają regulamin lub powszechnie obowiązujące przepisy. W takim przypadku użytkownikowi nie przysługuje zwrot poniesionych kosztów, jeżeli naruszenie wynikało z jego zawinionego działania."
+        ]
+      },
+      {
+        "title": "4. Minimalna odpowiedzialność",
+        "paragraphs": [
+          "4.1. Administrator ponosi odpowiedzialność wobec użytkownika jedynie w granicach rzeczywistej szkody, będącej bezpośrednim i zawinionym następstwem niewykonania lub nienależytego wykonania usługi. Odpowiedzialność za utracone korzyści jest wyłączona w najszerszym dopuszczalnym przez prawo zakresie.",
+          "4.2. Administrator nie odpowiada za szkody wynikłe z:"
+        ],
+        "list": [
+          "działań lub zaniechań użytkownika lub osób trzecich,",
+          "zdarzeń siły wyższej, awarii sieci telekomunikacyjnych, serwerów lub oprogramowania,",
+          "zawieszenia lub zakończenia świadczenia usług wynikających z naruszenia regulaminu przez użytkownika."
+        ]
+      },
+      {
+        "title": "5. Brak gwarancji",
+        "paragraphs": [
+          "5.1. Serwis KupPixel świadczony jest w stanie „takim, jaki jest”. Administrator nie udziela żadnej gwarancji, w tym gwarancji przydatności do określonego celu, ciągłej dostępności czy bezbłędnego działania serwisu.",
+          "5.2. Administrator nie gwarantuje skuteczności działań marketingowych prowadzonych przez użytkownika przy użyciu nabytych pikseli ani liczby odwiedzin generowanych przez linki."
+        ]
+      },
+      {
+        "title": "6. Prawo do zmian oferty",
+        "paragraphs": [
+          "6.1. Administrator zastrzega sobie prawo do wprowadzania zmian w ofercie serwisu, w tym modyfikacji funkcjonalności, cennika, zasad przyznawania punktów oraz warunków promocji.",
+          "6.2. Zmiany wchodzą w życie w terminie wskazanym w ogłoszeniu zamieszczonym na stronie głównej serwisu. Użytkownicy zostaną o nich poinformowani co najmniej 7 dni wcześniej, chyba że zmiana wynika z nagłej potrzeby zapewnienia bezpieczeństwa serwisu.",
+          "6.3. Kontynuowanie korzystania z serwisu po wejściu w życie zmian oznacza ich akceptację. W przypadku braku zgody użytkownik ma prawo do rozwiązania umowy ze skutkiem natychmiastowym."
+        ]
+      },
+      {
+        "title": "7. Prawa autorskie i treści użytkowników",
+        "paragraphs": [
+          "7.1. Użytkownik publikujący treści w serwisie oświadcza, że posiada prawa do ich rozpowszechniania lub uzyskał odpowiednie zgody.",
+          "7.2. Użytkownik udziela administratorowi niewyłącznej licencji na publiczne wyświetlanie oraz przechowywanie publikowanych materiałów w zakresie koniecznym do realizacji usług.",
+          "7.3. Administrator może usuwać treści naruszające prawo lub regulamin, a także blokować konta użytkowników dopuszczających się powtarzających naruszeń."
+        ]
+      },
+      {
+        "title": "8. Reklamacje",
+        "paragraphs": [
+          "8.1. Reklamacje dotyczące funkcjonowania serwisu można składać drogą elektroniczną na adres reklamacje@kuppixel.pl w terminie 30 dni od wystąpienia zdarzenia będącego podstawą reklamacji.",
+          "8.2. Reklamacja powinna zawierać dane umożliwiające identyfikację użytkownika oraz opis zgłaszanych zastrzeżeń. Administrator rozpatrzy zgłoszenie w terminie 14 dni roboczych od daty otrzymania.",
+          "8.3. W przypadku braku możliwości rozpatrzenia reklamacji w podanym terminie, administrator poinformuje użytkownika o przyczynach opóźnienia i wskaże przewidywany termin udzielenia odpowiedzi."
+        ]
+      },
+      {
+        "title": "9. Dane osobowe",
+        "paragraphs": [
+          "9.1. Administratorem danych osobowych użytkowników jest KupPixel Sp. z o.o. Dane przetwarzane są w celu realizacji usług elektronicznych i obsługi kont użytkownika zgodnie z polityką prywatności.",
+          "9.2. Użytkownikowi przysługuje prawo dostępu do treści swoich danych oraz ich poprawiania, ograniczenia przetwarzania, przenoszenia i usunięcia na zasadach określonych w obowiązujących przepisach."
+        ]
+      },
+      {
+        "title": "10. Postanowienia końcowe",
+        "paragraphs": [
+          "10.1. W sprawach nieuregulowanych regulaminem zastosowanie mają przepisy prawa polskiego, w szczególności ustawy o świadczeniu usług drogą elektroniczną oraz Kodeksu cywilnego.",
+          "10.2. Spory wynikłe z korzystania z serwisu rozstrzygane będą przez właściwe sądy powszechne. Użytkownik będący konsumentem może skorzystać z pozasądowych sposobów rozpatrywania sporów i dochodzenia roszczeń.",
+          "10.3. Regulamin wchodzi w życie z dniem jego publikacji na stronie serwisu."
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,14 +3,17 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { I18nProvider } from "./lang/I18nProvider";
 import { AuthProvider } from "./useAuth";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <I18nProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </I18nProvider>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- finish wiring frontend components into the new i18n provider, including the verification flow and pixel canvas accessibility text
- extend the translation dictionaries with purchase result labels and selection summaries for both Polish and English
- ensure the purchase results list in the buy flow relies on localized labels rather than hard-coded strings

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1b9cbe30c8326a62b01135ca59611