### PR TITLE
Add localized password reset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ Kluczowe opcje:
 | Pole | Opis |
 | --- | --- |
 | `disableVerificationEmail` | Po ustawieniu na `true` nowi użytkownicy są automatycznie oznaczani jako zweryfikowani i nie są wysyłane żadne maile. |
+| `email.language` | Ustala język wiadomości transakcyjnych (np. `pl` lub `en`) wykorzystywanych przy weryfikacji konta i resetowaniu haseł. |
+| `passwordReset.baseUrl` | Opcjonalna baza URL używana do budowy linków resetujących hasło (domyślnie wartość zmiennej `PASSWORD_RESET_LINK_BASE_URL` lub adres weryfikacyjny). |
+| `passwordReset.tokenTtlHours` | Liczba godzin, przez które link resetujący hasło pozostaje ważny. |
 | `smtp` | (Opcjonalnie) konfiguracja transportu SMTP oparta na polach `host`, `port`, `username`, `password`, `fromEmail`, `fromName`. |
 
 Jeżeli sekcja `smtp` jest pominięta lub pusta, backend pozostaje w trybie developerskim – link aktywacyjny pojawia się w logach (ConsoleMailer). Po poprawnym uzupełnieniu danych zostanie użyty prawdziwy serwer SMTP.
+
+Reset haseł korzysta z endpointów `/api/password-reset/request` i `/api/password-reset/confirm`. Linki są budowane w oparciu o `passwordReset.baseUrl` (lub zmienną środowiskową `PASSWORD_RESET_LINK_BASE_URL`) i mają okres ważności określony przez `passwordReset.tokenTtlHours`.
 
 ### 💾 Przechowywanie danych backendu
 

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -3,6 +3,16 @@
   "pixelCostPoints": 10,
   // Set to true to automatically mark newly created accounts as verified and skip emails.
   "disableVerificationEmail": false,
+  "email": {
+    // Controls the language used in verification and password reset emails. Supported values: "pl", "en".
+    "language": "pl"
+  },
+  "passwordReset": {
+    // Base URL used to construct password reset links (fallbacks to PASSWORD_RESET_LINK_BASE_URL or VERIFICATION_LINK_BASE_URL).
+    "baseUrl": "http://localhost:3000",
+    // Password reset token time to live in hours.
+    "tokenTtlHours": 24
+  },
   "database": {
     "driver": "sqlite",
     // Optional override for sqlite database path; defaults to PIXEL_DB_PATH or data/pixels_new.db.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -18,6 +18,19 @@ type Config struct {
 	DisableVerificationEmail bool              `json:"disableVerificationEmail"`
 	PixelCostPoints          int               `json:"pixelCostPoints"`
 	Database                 *DatabaseConfig   `json:"database"`
+	Email                    EmailConfig       `json:"email"`
+	PasswordReset            PasswordReset     `json:"passwordReset"`
+}
+
+// EmailConfig controls localisation of transactional emails sent by the backend.
+type EmailConfig struct {
+	Language string `json:"language"`
+}
+
+// PasswordReset holds configuration for password reset tokens and links.
+type PasswordReset struct {
+	TokenTTLHours int    `json:"tokenTtlHours"`
+	BaseURL       string `json:"baseUrl"`
 }
 
 // DatabaseConfig encapsulates storage backend configuration.
@@ -66,6 +79,8 @@ func Default() *Config {
 		DisableVerificationEmail: false,
 		PixelCostPoints:          10,
 		Database:                 defaultDatabaseConfig(),
+		Email:                    EmailConfig{Language: "pl"},
+		PasswordReset:            PasswordReset{TokenTTLHours: 24},
 	}
 }
 
@@ -123,6 +138,16 @@ func Load(path string) (*Config, error) {
 	if cfg.PixelCostPoints <= 0 {
 		cfg.PixelCostPoints = Default().PixelCostPoints
 	}
+
+	cfg.Email.Language = strings.ToLower(strings.TrimSpace(cfg.Email.Language))
+	if cfg.Email.Language == "" {
+		cfg.Email.Language = Default().Email.Language
+	}
+
+	if cfg.PasswordReset.TokenTTLHours <= 0 {
+		cfg.PasswordReset.TokenTTLHours = Default().PasswordReset.TokenTTLHours
+	}
+	cfg.PasswordReset.BaseURL = strings.TrimSpace(cfg.PasswordReset.BaseURL)
 
 	if cfg.Database == nil {
 		cfg.Database = defaultDatabaseConfig()

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -43,6 +43,12 @@ func TestLoad_DisableVerificationWithoutSMTP(t *testing.T) {
 	if cfg.Database.Driver != "sqlite" {
 		t.Fatalf("expected sqlite driver, got %q", cfg.Database.Driver)
 	}
+	if cfg.Email.Language != "pl" {
+		t.Fatalf("expected default email language pl, got %q", cfg.Email.Language)
+	}
+	if cfg.PasswordReset.TokenTTLHours != Default().PasswordReset.TokenTTLHours {
+		t.Fatalf("expected default reset ttl, got %d", cfg.PasswordReset.TokenTTLHours)
+	}
 }
 
 func TestLoad_WithValidSMTP(t *testing.T) {
@@ -80,6 +86,12 @@ func TestLoad_WithValidSMTP(t *testing.T) {
 	}
 	if cfg.Database.Driver != "sqlite" {
 		t.Fatalf("expected sqlite driver by default, got %q", cfg.Database.Driver)
+	}
+	if cfg.Email.Language != "pl" {
+		t.Fatalf("expected default email language pl, got %q", cfg.Email.Language)
+	}
+	if cfg.PasswordReset.TokenTTLHours != Default().PasswordReset.TokenTTLHours {
+		t.Fatalf("expected default reset ttl, got %d", cfg.PasswordReset.TokenTTLHours)
 	}
 }
 
@@ -152,5 +164,11 @@ func TestWriteFile_DefaultConfig(t *testing.T) {
 	}
 	if cfg.Database.Driver != "sqlite" {
 		t.Fatalf("expected sqlite driver, got %q", cfg.Database.Driver)
+	}
+	if cfg.Email.Language != "pl" {
+		t.Fatalf("expected default email language pl, got %q", cfg.Email.Language)
+	}
+	if cfg.PasswordReset.TokenTTLHours != Default().PasswordReset.TokenTTLHours {
+		t.Fatalf("expected default reset ttl, got %d", cfg.PasswordReset.TokenTTLHours)
 	}
 }

--- a/backend/internal/email/mailer.go
+++ b/backend/internal/email/mailer.go
@@ -11,21 +11,23 @@ import (
 // Mailer is responsible for delivering transactional emails to users.
 type Mailer interface {
 	SendVerificationEmail(ctx context.Context, recipient, verificationLink string) error
+	SendPasswordResetEmail(ctx context.Context, recipient, resetLink string) error
 }
 
 // ConsoleMailer logs outgoing emails instead of delivering them.
 // It is useful for development environments where SMTP access is not available.
 type ConsoleMailer struct {
 	FromName string
+	locale   localeContent
 }
 
 // NewConsoleMailer creates a ConsoleMailer with the provided sender label.
-func NewConsoleMailer(fromName string) *ConsoleMailer {
+func NewConsoleMailer(fromName, language string) *ConsoleMailer {
 	name := strings.TrimSpace(fromName)
 	if name == "" {
 		name = "Kup Piksel"
 	}
-	return &ConsoleMailer{FromName: name}
+	return &ConsoleMailer{FromName: name, locale: resolveLocale(language)}
 }
 
 // SendVerificationEmail logs the verification link so developers can copy it.
@@ -44,8 +46,61 @@ func (m *ConsoleMailer) SendVerificationEmail(ctx context.Context, recipient, ve
 		return fmt.Errorf("invalid verification link: %w", err)
 	}
 
-	log.Printf("[email] To: %s | Subject: Potwierdź swój adres e-mail | Link: %s", strings.TrimSpace(recipient), link)
+	log.Printf("[email] To: %s | Subject: %s | Link: %s", strings.TrimSpace(recipient), m.locale.verificationSubject, link)
 	return nil
 }
 
 var _ Mailer = (*ConsoleMailer)(nil)
+
+// SendPasswordResetEmail logs the reset link for developers.
+func (m *ConsoleMailer) SendPasswordResetEmail(ctx context.Context, recipient, resetLink string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	link := strings.TrimSpace(resetLink)
+	if link == "" {
+		return fmt.Errorf("reset link must not be empty")
+	}
+	if _, err := url.Parse(link); err != nil {
+		return fmt.Errorf("invalid reset link: %w", err)
+	}
+
+	log.Printf("[email] To: %s | Subject: %s | Link: %s", strings.TrimSpace(recipient), m.locale.resetSubject, link)
+	return nil
+}
+
+type localeContent struct {
+	verificationSubject string
+	verificationBody    string
+	resetSubject        string
+	resetBody           string
+}
+
+var locales = map[string]localeContent{
+	"pl": {
+		verificationSubject: "Potwierdź swój adres e-mail",
+		verificationBody:    "Cześć!\n\nKliknij poniższy link, aby potwierdzić swoje konto w Kup Piksel:\n%s\n\nJeżeli to nie Ty zakładałeś konto, zignoruj tę wiadomość.\n",
+		resetSubject:        "Zresetuj swoje hasło",
+		resetBody:           "Cześć!\n\nKliknij poniższy link, aby ustawić nowe hasło do konta w Kup Piksel:\n%s\n\nJeżeli to nie Ty prosiłeś o reset hasła, zignoruj tę wiadomość.\n",
+	},
+	"en": {
+		verificationSubject: "Confirm your email address",
+		verificationBody:    "Hello!\n\nClick the link below to confirm your Kup Piksel account:\n%s\n\nIf you didn't create an account, please ignore this message.\n",
+		resetSubject:        "Reset your password",
+		resetBody:           "Hello!\n\nClick the link below to set a new password for your Kup Piksel account:\n%s\n\nIf you didn't request a password reset, please ignore this message.\n",
+	},
+}
+
+func resolveLocale(language string) localeContent {
+	lang := strings.ToLower(strings.TrimSpace(language))
+	if lang == "" {
+		lang = "pl"
+	}
+	if content, ok := locales[lang]; ok {
+		return content
+	}
+	return locales["pl"]
+}

--- a/backend/internal/storage/mysql/migrations/002_password_reset.sql
+++ b/backend/internal/storage/mysql/migrations/002_password_reset.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    token VARCHAR(128) NOT NULL,
+    user_id BIGINT NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (token),
+    CONSTRAINT fk_password_reset_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_password_reset_tokens_user (user_id)
+) ENGINE=InnoDB;

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -38,6 +38,13 @@ type VerificationToken struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+type PasswordResetToken struct {
+	Token     string    `json:"token"`
+	UserID    int64     `json:"user_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 type PixelState struct {
 	Width  int     `json:"width"`
 	Height int     `json:"height"`
@@ -69,4 +76,9 @@ type Store interface {
 	DeleteVerificationToken(ctx context.Context, token string) error
 	DeleteVerificationTokensForUser(ctx context.Context, userID int64) error
 	MarkUserVerified(ctx context.Context, userID int64) error
+	CreatePasswordResetToken(ctx context.Context, token string, userID int64, expiresAt time.Time) (PasswordResetToken, error)
+	GetPasswordResetToken(ctx context.Context, token string) (PasswordResetToken, error)
+	DeletePasswordResetToken(ctx context.Context, token string) error
+	DeletePasswordResetTokensForUser(ctx context.Context, userID int64) error
+	UpdateUserPassword(ctx context.Context, userID int64, passwordHash string) error
 }

--- a/backend/main_password_reset_test.go
+++ b/backend/main_password_reset_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	gin "github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/example/kup-piksel/internal/storage/sqlite"
+)
+
+func TestPasswordResetFlow(t *testing.T) {
+	store, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	store.SetSkipPixelSeed(true)
+	if err := store.EnsureSchema(context.Background()); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("initial"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	user, err := store.CreateUser(context.Background(), "user@example.com", string(hash))
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	mailer := &fakeMailer{}
+	server := &Server{
+		store:                 store,
+		sessions:              NewSessionManager(),
+		mailer:                mailer,
+		verificationBaseURL:   "http://example.com",
+		verificationTokenTTL:  time.Hour,
+		passwordResetBaseURL:  "http://example.com",
+		passwordResetTokenTTL: time.Hour,
+		pixelCostPoints:       10,
+	}
+
+	body := bytes.NewBufferString(`{"email":"user@example.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/password-reset/request", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c := &gin.Context{Writer: w, Request: req}
+
+	server.handlePasswordResetRequest(c)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected status 202, got %d", w.Code)
+	}
+	if mailer.resetSent != 1 {
+		t.Fatalf("expected one reset email, got %d", mailer.resetSent)
+	}
+	if mailer.lastResetLink == "" {
+		t.Fatalf("expected reset link to be set")
+	}
+
+	parsed, err := url.Parse(mailer.lastResetLink)
+	if err != nil {
+		t.Fatalf("parse link: %v", err)
+	}
+	token := parsed.Query().Get("token")
+	if token == "" {
+		t.Fatalf("expected token in reset link")
+	}
+
+	record, err := store.GetPasswordResetToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("get password reset token: %v", err)
+	}
+	if record.UserID != user.ID {
+		t.Fatalf("expected token to belong to user %d, got %d", user.ID, record.UserID)
+	}
+
+	confirmBody := bytes.NewBufferString(`{"token":"` + token + `","password":"new-secret"}`)
+	confirmReq := httptest.NewRequest(http.MethodPost, "/api/password-reset/confirm", confirmBody)
+	confirmReq.Header.Set("Content-Type", "application/json")
+	confirmW := httptest.NewRecorder()
+	confirmCtx := &gin.Context{Writer: confirmW, Request: confirmReq}
+
+	server.handlePasswordResetConfirm(confirmCtx)
+
+	if confirmW.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", confirmW.Code)
+	}
+
+	updated, err := store.GetUserByEmail(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("get user after reset: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(updated.PasswordHash), []byte("new-secret")); err != nil {
+		t.Fatalf("expected password to be updated: %v", err)
+	}
+
+	if _, err := store.GetPasswordResetToken(context.Background(), token); err == nil {
+		t.Fatalf("expected reset token to be removed")
+	}
+}

--- a/backend/main_register_test.go
+++ b/backend/main_register_test.go
@@ -20,12 +20,21 @@ type fakeMailer struct {
 	sent          int
 	lastRecipient string
 	lastLink      string
+	resetSent     int
+	lastResetLink string
 }
 
 func (f *fakeMailer) SendVerificationEmail(ctx context.Context, recipient, verificationLink string) error {
 	f.sent++
 	f.lastRecipient = recipient
 	f.lastLink = verificationLink
+	return nil
+}
+
+func (f *fakeMailer) SendPasswordResetEmail(ctx context.Context, recipient, resetLink string) error {
+	f.resetSent++
+	f.lastRecipient = recipient
+	f.lastResetLink = resetLink
 	return nil
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import ActivationCodeModal from "./components/ActivationCodeModal";
 import TermsFooter from "./components/TermsFooter";
 import NavigationBar from "./components/NavigationBar";
 import TermsPage from "./components/TermsPage";
+import ForgotPasswordPage from "./components/ForgotPasswordPage";
+import ResetPasswordPage from "./components/ResetPasswordPage";
 import { useAuth } from "./useAuth";
 import { useI18n } from "./lang/I18nProvider";
 
@@ -694,6 +696,22 @@ export default function App() {
           element={
             <PageLayout onOpenRegister={handleOpenRegister}>
               <VerifyAccountPage />
+            </PageLayout>
+          }
+        />
+        <Route
+          path="/forgot-password"
+          element={
+            <PageLayout onOpenRegister={handleOpenRegister}>
+              <ForgotPasswordPage />
+            </PageLayout>
+          }
+        />
+        <Route
+          path="/reset-password"
+          element={
+            <PageLayout onOpenRegister={handleOpenRegister}>
+              <ResetPasswordPage />
             </PageLayout>
           }
         />

--- a/frontend/src/components/ForgotPasswordPage.tsx
+++ b/frontend/src/components/ForgotPasswordPage.tsx
@@ -1,0 +1,86 @@
+import { FormEvent, useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../useAuth";
+import { useI18n } from "../lang/I18nProvider";
+
+export default function ForgotPasswordPage() {
+  const { requestPasswordReset } = useAuth();
+  const { t } = useI18n();
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("idle");
+    setError("");
+    setMessage("");
+    setIsSubmitting(true);
+    try {
+      const result = await requestPasswordReset(email.trim());
+      setMessage(result);
+      setStatus("success");
+    } catch (err) {
+      console.error("password reset request", err);
+      const fallback = err instanceof Error ? err.message : t("auth.passwordReset.errors.request");
+      setError(fallback);
+      setStatus("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-full flex-col items-center justify-center px-4 py-16 text-center text-slate-200">
+      <div className="w-full max-w-xl rounded-3xl bg-slate-900/80 p-10 shadow-2xl ring-1 ring-white/10">
+        <h1 className="text-3xl font-semibold text-blue-400">{t("auth.passwordReset.title")}</h1>
+        <p className="mt-2 text-sm text-slate-300">{t("auth.passwordReset.description")}</p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-4 text-left">
+          <label className="block text-sm font-medium text-slate-200">
+            {t("common.labels.email")}
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
+              required
+              autoComplete="email"
+              disabled={isSubmitting}
+            />
+          </label>
+
+          {status === "error" && error && (
+            <p role="alert" className="text-sm text-rose-400">
+              {error}
+            </p>
+          )}
+
+          {status === "success" && message && (
+            <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+              {message}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-3 pt-4">
+            <Link
+              to="/"
+              className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
+            >
+              {t("common.actions.goHome")}
+            </Link>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? t("common.status.sending") : t("auth.passwordReset.submit")}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,10 +1,12 @@
 import { FormEvent, useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuth } from "../useAuth";
 import ResendVerificationForm from "./ResendVerificationForm";
 import { useI18n } from "../lang/I18nProvider";
 
 export default function LoginModal() {
   const { isLoginModalOpen, closeLoginModal, login, loginPrompt } = useAuth();
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -23,6 +25,13 @@ export default function LoginModal() {
     resetState();
     closeLoginModal();
   }, [closeLoginModal, isSubmitting, resetState]);
+
+  const handleForgotPassword = useCallback(() => {
+    if (isSubmitting) return;
+    resetState();
+    closeLoginModal();
+    navigate("/forgot-password");
+  }, [closeLoginModal, isSubmitting, navigate, resetState]);
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -102,6 +111,17 @@ export default function LoginModal() {
               disabled={isSubmitting}
             />
           </label>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleForgotPassword}
+              className="text-sm font-medium text-blue-400 transition hover:text-blue-300"
+              disabled={isSubmitting}
+            >
+              {t("auth.passwordReset.link")}
+            </button>
+          </div>
 
           {error && (
             <p role="alert" className="text-sm text-rose-400">

--- a/frontend/src/components/ResetPasswordPage.tsx
+++ b/frontend/src/components/ResetPasswordPage.tsx
@@ -1,0 +1,110 @@
+import { FormEvent, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useAuth } from "../useAuth";
+import { useI18n } from "../lang/I18nProvider";
+
+export default function ResetPasswordPage() {
+  const { confirmPasswordReset, openLoginModal } = useAuth();
+  const { t } = useI18n();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<"idle" | "success" | "error">(token ? "idle" : "error");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState(() => (token ? "" : t("auth.passwordReset.errors.missingToken")));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!token) {
+      setError(t("auth.passwordReset.errors.missingToken"));
+      setStatus("error");
+      return;
+    }
+    if (!password.trim()) {
+      setError(t("auth.passwordReset.errors.passwordRequired"));
+      setStatus("error");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatus("idle");
+    setError("");
+    setMessage("");
+    try {
+      const result = await confirmPasswordReset(token, password.trim());
+      setMessage(result);
+      setStatus("success");
+    } catch (err) {
+      console.error("password reset confirm", err);
+      const fallback = err instanceof Error ? err.message : t("auth.passwordReset.errors.confirm");
+      setError(fallback);
+      setStatus("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOpenLogin = () => {
+    void openLoginModal({ message: t("auth.errors.loginToStart") });
+  };
+
+  return (
+    <div className="flex min-h-full flex-col items-center justify-center px-4 py-16 text-center text-slate-200">
+      <div className="w-full max-w-xl rounded-3xl bg-slate-900/80 p-10 shadow-2xl ring-1 ring-white/10">
+        <h1 className="text-3xl font-semibold text-blue-400">{t("auth.passwordReset.confirmTitle")}</h1>
+        <p className="mt-2 text-sm text-slate-300">{t("auth.passwordReset.confirmDescription")}</p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-4 text-left">
+          <label className="block text-sm font-medium text-slate-200">
+            {t("common.labels.password")}
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/70 px-4 py-3 text-slate-100 shadow-inner focus:border-blue-400 focus:outline-none"
+              required
+              autoComplete="new-password"
+              disabled={isSubmitting}
+            />
+          </label>
+
+          {status === "error" && error && (
+            <p role="alert" className="text-sm text-rose-400">
+              {error}
+            </p>
+          )}
+
+          {status === "success" && message && (
+            <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+              {message}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center justify-end gap-3 pt-4">
+            <button
+              type="button"
+              onClick={handleOpenLogin}
+              className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
+            >
+              {t("common.actions.openLogin")}
+            </button>
+            <Link
+              to="/"
+              className="rounded-full px-4 py-2 text-sm font-semibold text-slate-300 transition hover:text-slate-100"
+            >
+              {t("common.actions.goHome")}
+            </Link>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-full bg-blue-500 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? t("common.status.sending") : t("auth.passwordReset.confirmSubmit")}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -126,6 +126,23 @@
       "verifyResendDescription": "Enter your email address to receive a new verification token.",
       "verifyErrorTitle": "Could not verify the account",
       "verifyReady": "All set!"
+    },
+    "passwordReset": {
+      "title": "Reset your password",
+      "description": "Enter your email address to receive reset instructions.",
+      "submit": "Send reset link",
+      "success": "If the account exists, we sent reset instructions to your email.",
+      "link": "Forgot password?",
+      "confirmTitle": "Set a new password",
+      "confirmDescription": "Choose a new password for your account.",
+      "confirmSubmit": "Update password",
+      "confirmSuccess": "Password updated. You can sign in now.",
+      "errors": {
+        "request": "Failed to request password reset. Please try again.",
+        "confirm": "Failed to reset password. Please try again.",
+        "missingToken": "Reset token is missing or invalid.",
+        "passwordRequired": "Enter a new password."
+      }
     }
   },
   "landing": {

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -126,6 +126,23 @@
       "verifyResendDescription": "Wpisz swój adres e-mail, aby otrzymać nowy token weryfikacyjny.",
       "verifyErrorTitle": "Nie udało się potwierdzić konta",
       "verifyReady": "Gotowe!"
+    },
+    "passwordReset": {
+      "title": "Zresetuj hasło",
+      "description": "Podaj adres e-mail, aby otrzymać instrukcje resetu.",
+      "submit": "Wyślij link resetujący",
+      "success": "Jeśli konto istnieje, wysłaliśmy instrukcje resetu na Twój adres e-mail.",
+      "link": "Nie pamiętasz hasła?",
+      "confirmTitle": "Ustaw nowe hasło",
+      "confirmDescription": "Wpisz nowe hasło dla swojego konta.",
+      "confirmSubmit": "Zapisz nowe hasło",
+      "confirmSuccess": "Hasło zostało zaktualizowane. Możesz się teraz zalogować.",
+      "errors": {
+        "request": "Nie udało się wysłać prośby o reset hasła. Spróbuj ponownie.",
+        "confirm": "Nie udało się zresetować hasła. Spróbuj ponownie.",
+        "missingToken": "Brak lub nieprawidłowy token resetujący.",
+        "passwordRequired": "Podaj nowe hasło."
+      }
     }
   },
   "landing": {

--- a/frontend/tests/activationCode.test.ts
+++ b/frontend/tests/activationCode.test.ts
@@ -1,6 +1,8 @@
 // @ts-ignore - node type definitions are not available in this environment
 import assert from "node:assert/strict";
 import { getActivationCodePattern, isActivationCodeValid, normalizeActivationCode } from "../src/utils/activationCode.js";
+import en from "../src/lang/en.json" with { type: "json" };
+import pl from "../src/lang/pl.json" with { type: "json" };
 
 declare const process: { exitCode?: number };
 
@@ -48,4 +50,19 @@ test("isActivationCodeValid rejects invalid codes", () => {
 test("normalizeActivationCode output matches API pattern", () => {
   const normalized = normalizeActivationCode("a1b2-c3d4-e5f6-g7h8");
   assert.equal(getActivationCodePattern().test(normalized), true);
+});
+
+function collectKeys(record: Record<string, unknown>): string[] {
+  return Object.keys(record).sort();
+}
+
+test("password reset translations are aligned", () => {
+  const enPasswordReset = (en.auth as Record<string, unknown>).passwordReset as Record<string, unknown>;
+  const plPasswordReset = (pl.auth as Record<string, unknown>).passwordReset as Record<string, unknown>;
+  assert.ok(enPasswordReset, "english password reset section missing");
+  assert.ok(plPasswordReset, "polish password reset section missing");
+  assert.deepEqual(collectKeys(enPasswordReset), collectKeys(plPasswordReset));
+  const enErrors = enPasswordReset.errors as Record<string, unknown>;
+  const plErrors = plPasswordReset.errors as Record<string, unknown>;
+  assert.deepEqual(collectKeys(enErrors), collectKeys(plErrors));
 });


### PR DESCRIPTION
## Summary
- add configurable email language and password reset support to backend config, storage, mailers, and HTTP routes
- extend backend tests and migrations to cover issuing reset tokens and updating passwords
- add frontend password reset pages, translations, and auth helpers along with updated login modal messaging

## Testing
- go test ./...
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1c44ded808326b85ce4d1ee8dccf8