### PR TITLE
Redirect after password reset and configure verification TTL

### DIFF
--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -7,6 +7,10 @@
     // Controls the language used in verification and password reset emails. Supported values: "pl", "en".
     "language": "pl"
   },
+  "verification": {
+    // Verification token time to live in hours.
+    "tokenTtlHours": 24
+  },
   "passwordReset": {
     // Base URL used to construct password reset links (fallbacks to PASSWORD_RESET_LINK_BASE_URL or VERIFICATION_LINK_BASE_URL).
     "baseUrl": "http://localhost:3000",

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Database                 *DatabaseConfig   `json:"database"`
 	Email                    EmailConfig       `json:"email"`
 	PasswordReset            PasswordReset     `json:"passwordReset"`
+	Verification             Verification      `json:"verification"`
 }
 
 // EmailConfig controls localisation of transactional emails sent by the backend.
@@ -31,6 +32,11 @@ type EmailConfig struct {
 type PasswordReset struct {
 	TokenTTLHours int    `json:"tokenTtlHours"`
 	BaseURL       string `json:"baseUrl"`
+}
+
+// Verification holds configuration for verification tokens and links.
+type Verification struct {
+	TokenTTLHours int `json:"tokenTtlHours"`
 }
 
 // DatabaseConfig encapsulates storage backend configuration.
@@ -81,6 +87,7 @@ func Default() *Config {
 		Database:                 defaultDatabaseConfig(),
 		Email:                    EmailConfig{Language: "pl"},
 		PasswordReset:            PasswordReset{TokenTTLHours: 24},
+		Verification:             Verification{TokenTTLHours: 24},
 	}
 }
 
@@ -148,6 +155,10 @@ func Load(path string) (*Config, error) {
 		cfg.PasswordReset.TokenTTLHours = Default().PasswordReset.TokenTTLHours
 	}
 	cfg.PasswordReset.BaseURL = strings.TrimSpace(cfg.PasswordReset.BaseURL)
+
+	if cfg.Verification.TokenTTLHours <= 0 {
+		cfg.Verification.TokenTTLHours = Default().Verification.TokenTTLHours
+	}
 
 	if cfg.Database == nil {
 		cfg.Database = defaultDatabaseConfig()

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -49,6 +49,9 @@ func TestLoad_DisableVerificationWithoutSMTP(t *testing.T) {
 	if cfg.PasswordReset.TokenTTLHours != Default().PasswordReset.TokenTTLHours {
 		t.Fatalf("expected default reset ttl, got %d", cfg.PasswordReset.TokenTTLHours)
 	}
+	if cfg.Verification.TokenTTLHours != Default().Verification.TokenTTLHours {
+		t.Fatalf("expected default verification ttl, got %d", cfg.Verification.TokenTTLHours)
+	}
 }
 
 func TestLoad_WithValidSMTP(t *testing.T) {
@@ -93,6 +96,9 @@ func TestLoad_WithValidSMTP(t *testing.T) {
 	if cfg.PasswordReset.TokenTTLHours != Default().PasswordReset.TokenTTLHours {
 		t.Fatalf("expected default reset ttl, got %d", cfg.PasswordReset.TokenTTLHours)
 	}
+	if cfg.Verification.TokenTTLHours != Default().Verification.TokenTTLHours {
+		t.Fatalf("expected default verification ttl, got %d", cfg.Verification.TokenTTLHours)
+	}
 }
 
 func TestLoad_InvalidSMTP(t *testing.T) {
@@ -106,6 +112,20 @@ func TestLoad_InvalidSMTP(t *testing.T) {
 
 	if _, err := Load(path); err == nil {
 		t.Fatal("expected error when SMTP is invalid")
+	}
+}
+
+func TestLoad_CustomVerificationTTL(t *testing.T) {
+	path := writeTempConfig(t, `{
+                "verification": {"tokenTtlHours": 12}
+        }`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Verification.TokenTTLHours != 12 {
+		t.Fatalf("expected verification ttl 12, got %d", cfg.Verification.TokenTTLHours)
 	}
 }
 
@@ -170,5 +190,8 @@ func TestWriteFile_DefaultConfig(t *testing.T) {
 	}
 	if cfg.PasswordReset.TokenTTLHours != Default().PasswordReset.TokenTTLHours {
 		t.Fatalf("expected default reset ttl, got %d", cfg.PasswordReset.TokenTTLHours)
+	}
+	if cfg.Verification.TokenTTLHours != Default().Verification.TokenTTLHours {
+		t.Fatalf("expected default verification ttl, got %d", cfg.Verification.TokenTTLHours)
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -401,6 +401,11 @@ func main() {
 		passwordResetBaseURL = verificationBaseURL
 	}
 
+	verificationTTL := time.Duration(cfg.Verification.TokenTTLHours) * time.Hour
+	if verificationTTL <= 0 {
+		verificationTTL = defaultVerificationTTL
+	}
+
 	passwordResetTTL := time.Duration(cfg.PasswordReset.TokenTTLHours) * time.Hour
 	if passwordResetTTL <= 0 {
 		passwordResetTTL = time.Duration(config.Default().PasswordReset.TokenTTLHours) * time.Hour
@@ -436,7 +441,7 @@ func main() {
 		sessions:                 NewSessionManager(),
 		mailer:                   mailer,
 		verificationBaseURL:      verificationBaseURL,
-		verificationTokenTTL:     defaultVerificationTTL,
+		verificationTokenTTL:     verificationTTL,
 		passwordResetBaseURL:     passwordResetBaseURL,
 		passwordResetTokenTTL:    passwordResetTTL,
 		disableVerificationEmail: cfg.DisableVerificationEmail,
@@ -444,10 +449,11 @@ func main() {
 	}
 
 	log.Printf(
-		"startup config: config_path=%s storage_backend=%s verification_base_url=%s password_reset_base_url=%s reset_ttl=%s smtp_configured=%t disable_verification_email=%t pixel_cost_points=%d email_language=%s",
+		"startup config: config_path=%s storage_backend=%s verification_base_url=%s verification_ttl=%s password_reset_base_url=%s reset_ttl=%s smtp_configured=%t disable_verification_email=%t pixel_cost_points=%d email_language=%s",
 		configPath,
 		storeDescription,
 		verificationBaseURL,
+		verificationTTL,
 		passwordResetBaseURL,
 		passwordResetTTL,
 		smtpConfigured,


### PR DESCRIPTION
## Summary
- redirect users to the homepage immediately after confirming a password reset
- add configurable verification token TTL support and propagate it through server setup
- document the new verification TTL option and extend config tests to cover it

## Testing
- go test ./...
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d1ecad20c48326aa5d7b24ef727de3