### PR TITLE
Configure Turnstile site key for frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.4
 
 FROM node:18-alpine AS frontend-builder
+ARG VITE_TURNSTILE_SITE_KEY="1x00000000000000000000AA"
+ENV VITE_TURNSTILE_SITE_KEY=${VITE_TURNSTILE_SITE_KEY}
 WORKDIR /app/frontend
 COPY frontend/package.json ./
 RUN --mount=type=cache,target=/root/.npm npm install

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Jeżeli sekcja `smtp` jest pominięta lub pusta, backend pozostaje w trybie deve
 
 Reset haseł korzysta z endpointów `/api/password-reset/request` i `/api/password-reset/confirm`. Linki są budowane w oparciu o `passwordReset.baseUrl` (lub zmienną środowiskową `PASSWORD_RESET_LINK_BASE_URL`) i mają okres ważności określony przez `passwordReset.tokenTtlHours`.
 
+### 🔐 Cloudflare Turnstile
+
+Aby formularze mogły wyświetlać widżet Cloudflare Turnstile, należy skonfigurować zarówno frontend, jak i backend:
+
+- **Frontend** oczekuje klucza publicznego w zmiennej `VITE_TURNSTILE_SITE_KEY`. Najprościej jest skopiować plik `frontend/.env.example` do `frontend/.env` i podmienić wartość na klucz z panelu Cloudflare. W przypadku budowania obrazu Dockera zmienna jest przekazywana jako argument `VITE_TURNSTILE_SITE_KEY`.
+- **Backend** używa sekretu z pola `turnstileSecretKey` w pliku `config.json`. Wartość ta musi odpowiadać sekretowi wygenerowanemu dla tej samej witryny w Cloudflare, co klucz publiczny z frontendu.
+
+Brak którejkolwiek z powyższych wartości uniemożliwi poprawne działanie weryfikacji CAPTCHA.
+
 ### 💾 Przechowywanie danych backendu
 
 - Domyślny plik bazy: `backend/data/pixels.db` (tworzony automatycznie przy starcie backendu).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.9"
 
 services:
   kup-piksel:
-    build: .
+    build:
+      context: .
+      args:
+        VITE_TURNSTILE_SITE_KEY: ${VITE_TURNSTILE_SITE_KEY:?Set VITE_TURNSTILE_SITE_KEY to your public Cloudflare Turnstile site key}
     ports:
       - "3000:3000"
     environment:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Public Cloudflare Turnstile site key used by the frontend bundle.
+# Replace the placeholder with the site key from your Cloudflare dashboard.
+VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,3 +1,13 @@
 const rawSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY;
 
-export const TURNSTILE_SITE_KEY = typeof rawSiteKey === "string" ? rawSiteKey.trim() : "";
+if (typeof rawSiteKey !== "string") {
+  throw new Error("VITE_TURNSTILE_SITE_KEY environment variable is not defined");
+}
+
+const normalizedSiteKey = rawSiteKey.trim();
+
+if (normalizedSiteKey.length === 0) {
+  throw new Error("VITE_TURNSTILE_SITE_KEY environment variable cannot be empty");
+}
+
+export const TURNSTILE_SITE_KEY = normalizedSiteKey;

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-readonly VITE_TURNSTILE_SITE_KEY?: string;
+  readonly VITE_TURNSTILE_SITE_KEY: string;
 }


### PR DESCRIPTION
## Summary
- make the frontend build fail fast when `VITE_TURNSTILE_SITE_KEY` is missing or empty and document the expected env typings
- provide a `.env` template, Docker build arguments, and compose configuration so the Turnstile site key reaches the bundle
- document how to configure both the frontend site key and backend secret for Cloudflare Turnstile

## Testing
- `cd frontend && VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA npm run build`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d3187c751483269f0b4c06333e2029