### PR TITLE
Add nginx reverse proxy configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,18 @@ services:
       - pixel-data:/app/data
       - ./backend/config.json:/app/config.json:ro
 
+  nginx:
+    image: nginx:alpine
+    container_name: kup-piksel-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    depends_on:
+      - kup-piksel
+
 volumes:
   pixel-data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,96 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+  log_format main '$remote_addr - $host [$time_local] "$request" $status $body_bytes_sent '
+                  '"$http_referer" "$http_user_agent" scheme=$scheme port=$server_port';
+  access_log /var/log/nginx/access.log main;
+
+  upstream app_upstream {
+    server kup-piksel:3000;
+    keepalive 16;
+  }
+
+  # HTTP -> HTTPS redirect
+  server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name kuppixel.pl www.kuppixel.pl;
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  # Main HTTPS server for kuppixel.pl and www.kuppixel.pl
+  server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
+    server_name kuppixel.pl www.kuppixel.pl;
+
+    ssl_certificate     /etc/nginx/ssl/fullchain.pem;    # Cloudflare Origin Cert fullchain
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;      # Cloudflare Origin Cert private key
+
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    # Trust Cloudflare IPs for real IP detection
+    real_ip_header CF-Connecting-IP;
+    real_ip_recursive on;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Port $server_port;
+
+      # Pass through Cloudflare headers
+      proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+      proxy_set_header CF-Ray $http_cf_ray;
+      proxy_set_header CF-Visitor $http_cf_visitor;
+
+      proxy_pass http://app_upstream/;
+      proxy_read_timeout 60s;
+      proxy_connect_timeout 30s;
+      proxy_send_timeout 60s;
+
+      # Buffer settings for better performance
+      proxy_buffering on;
+      proxy_buffer_size 128k;
+      proxy_buffers 4 256k;
+      proxy_busy_buffers_size 256k;
+    }
+  }
+
+  # Catch-all HTTPS server for other hosts
+  server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name _;
+    ssl_certificate     /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+
+      proxy_pass http://app_upstream/;
+      proxy_read_timeout 60s;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add production-ready nginx reverse proxy configuration tailored for KupPixel.pl
- extend docker-compose stack with nginx service that serves TLS traffic and forwards to the app container

## Testing
- unable to run `docker compose config` (docker not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d42bb0b8a48326b365ccac4db9b648