### PR TITLE
Mount local SSL certificates for nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./ssl:/etc/nginx/ssl:ro
+      - type: bind
+        source: ./ssl
+        target: /etc/nginx/ssl
+        read_only: true
     depends_on:
       - kup-piksel
 


### PR DESCRIPTION
## Summary
- bind-mount the repository ssl directory into the nginx container so that Cloudflare origin certificates stored alongside the project are used

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4364636148326a9ff391e29bef236