### PR TITLE
Remove nginx service from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,21 +15,5 @@ services:
       - pixel-data:/app/data
       - ./backend/config.json:/app/config.json:ro
 
-  nginx:
-    image: nginx:alpine
-    container_name: kup-piksel-nginx
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - type: bind
-        source: ./ssl
-        target: /etc/nginx/ssl
-        read_only: true
-    depends_on:
-      - kup-piksel
-
 volumes:
   pixel-data:


### PR DESCRIPTION
## Summary
- remove the standalone nginx service from docker-compose now that nginx is hosted elsewhere

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d442afc0e08326bacde2c2699044be