### PR TITLE
Track production nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Każdy piksel można kliknąć, zobaczyć czy jest wolny czy zajęty i w przysz�
 - **Backend**: Go (Gin framework) – API REST do obsługi pikseli
 - **Baza danych**: SQLite (plik tworzony domyślnie pod `backend/data/pixels.db`, można zmienić ścieżkę zmienną `PIXEL_DB_PATH`)
 - **Docker**: multi-stage build → jeden image z frontendem i backendem
-- **Nginx/Reverse Proxy**: opcjonalnie do hostingu na VPS + SSL
+- **Nginx/Reverse Proxy**: opcjonalnie do hostingu na VPS + SSL (konfiguracja produkcyjna w `infra/nginx/nginx.conf`)
 
 ### ✉️ Konfiguracja backendu
 

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -1,0 +1,12 @@
+# Konfiguracja Nginx (produkcyjna)
+
+Ten katalog zawiera plik `nginx.conf` wykorzystywany na serwerze reverse proxy w środowisku produkcyjnym.
+
+Plik odzwierciedla konfigurację kontenera Nginx, który terminując SSL rozsyła ruch na dwie aplikacje:
+
+- `kineflow.pl` → upstream `kineflow_upstream` (kontener `app:3000`)
+- `kuppixel.pl` → upstream `kuppixel_upstream` (kontener `kup-piksel:3000`)
+
+Serwer HTTP na porcie 80 służy wyłącznie do przekierowań na HTTPS, a blok `catch-all` na 443 zwraca kod 444 dla nieobsługiwanych hostów.
+
+Wszelkie zmiany w konfiguracji reverse proxy powinny być wprowadzane w tym pliku, a następnie wdrażane do kontenera Nginx.

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -7,38 +7,38 @@ http {
                   '"$http_referer" "$http_user_agent" scheme=$scheme port=$server_port';
   access_log /var/log/nginx/access.log main;
 
-  upstream app_upstream {
+  upstream kineflow_upstream {
+    server app:3000;
+    keepalive 16;
+  }
+
+  upstream kuppixel_upstream {
     server kup-piksel:3000;
     keepalive 16;
   }
 
-  # HTTP -> HTTPS redirect
   server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
-    server_name kuppixel.pl www.kuppixel.pl;
+    listen 80;
+    listen [::]:80;
+    server_name kineflow.pl www.kineflow.pl kuppixel.pl www.kuppixel.pl;
 
-    location / {
-      return 301 https://$host$request_uri;
-    }
+    return 301 https://$host$request_uri;
   }
 
-  # Main HTTPS server for kuppixel.pl and www.kuppixel.pl
   server {
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     http2 on;
-    server_name kuppixel.pl www.kuppixel.pl;
+    server_name kineflow.pl www.kineflow.pl;
 
-    ssl_certificate     /etc/nginx/ssl/fullchain.pem;    # Cloudflare Origin Cert fullchain
-    ssl_certificate_key /etc/nginx/ssl/privkey.pem;      # Cloudflare Origin Cert private key
+    ssl_certificate     /etc/nginx/ssl/kineflow/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/kineflow/privkey.pem;
 
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header Strict-Transport-Security "max-age=31536000" always;
 
-    # Trust Cloudflare IPs for real IP detection
     real_ip_header CF-Connecting-IP;
     real_ip_recursive on;
 
@@ -52,17 +52,15 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Port $server_port;
 
-      # Pass through Cloudflare headers
       proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
       proxy_set_header CF-Ray $http_cf_ray;
       proxy_set_header CF-Visitor $http_cf_visitor;
 
-      proxy_pass http://app_upstream/;
+      proxy_pass http://kineflow_upstream/;
       proxy_read_timeout 60s;
       proxy_connect_timeout 30s;
       proxy_send_timeout 60s;
 
-      # Buffer settings for better performance
       proxy_buffering on;
       proxy_buffer_size 128k;
       proxy_buffers 4 256k;
@@ -70,14 +68,22 @@ http {
     }
   }
 
-  # Catch-all HTTPS server for other hosts
   server {
     listen 443 ssl;
     listen [::]:443 ssl;
     http2 on;
-    server_name _;
-    ssl_certificate     /etc/nginx/ssl/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+    server_name kuppixel.pl www.kuppixel.pl;
+
+    ssl_certificate     /etc/nginx/ssl/kuppixel/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/kuppixel/privkey.pem;
+
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    real_ip_header CF-Connecting-IP;
+    real_ip_recursive on;
 
     location / {
       proxy_http_version 1.1;
@@ -87,10 +93,33 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+      proxy_set_header X-Forwarded-Port $server_port;
 
-      proxy_pass http://app_upstream/;
+      proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+      proxy_set_header CF-Ray $http_cf_ray;
+      proxy_set_header CF-Visitor $http_cf_visitor;
+
+      proxy_pass http://kuppixel_upstream/;
       proxy_read_timeout 60s;
+      proxy_connect_timeout 30s;
+      proxy_send_timeout 60s;
+
+      proxy_buffering on;
+      proxy_buffer_size 128k;
+      proxy_buffers 4 256k;
+      proxy_busy_buffers_size 256k;
     }
+  }
+
+  server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/ssl/kineflow/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/kineflow/privkey.pem;
+
+    return 444;
   }
 }


### PR DESCRIPTION
## Summary
- move the nginx reverse proxy configuration into infra/nginx/nginx.conf to match the container that is actually deployed
- document the purpose of the production nginx configuration so future changes land in the right place
- update the main README to point to the tracked nginx config instead of the unused root-level file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4494309548326bd2b06831abf573f