### PR TITLE
Guard nested user in parseUser

### DIFF
--- a/frontend/src/useAuth.tsx
+++ b/frontend/src/useAuth.tsx
@@ -79,11 +79,12 @@ export function parseUser(data: unknown): AuthUser | null {
   }
   if ("user" in data) {
     const nested = (data as Record<string, unknown>).user;
-    if (nested !== null && typeof nested === "object") {
-      const record = nested as Record<string, unknown>;
-      if ("email" in record && typeof record.email === "string") {
-        return record as AuthUser;
-      }
+    if (!nested || typeof nested !== "object") {
+      return null;
+    }
+    const record = nested as Record<string, unknown>;
+    if ("email" in record && typeof record.email === "string") {
+      return record as AuthUser;
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- add an early guard in `parseUser` to return null when the nested `user` payload is missing or non-object before checking its email

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a52063388326aaeb075d25a21d58