### PR TITLE
Add Elastic logging and Turnstile debug instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,27 @@ Aby formularze mogły wyświetlać widżet Cloudflare Turnstile, należy skonfig
 
 - **Frontend** oczekuje klucza publicznego w zmiennej `VITE_TURNSTILE_SITE_KEY`. Najprościej jest skopiować plik `frontend/.env.example` do `frontend/.env` i podmienić wartość na klucz z panelu Cloudflare. W przypadku budowania obrazu Dockera zmienna jest przekazywana jako argument `VITE_TURNSTILE_SITE_KEY`.
 - **Backend** używa sekretu z pola `turnstileSecretKey` w pliku `config.json`. Wartość ta musi odpowiadać sekretowi wygenerowanemu dla tej samej witryny w Cloudflare, co klucz publiczny z frontendu.
+- Dodatkowo można ustawić `VITE_TURNSTILE_DEBUG=true`, aby przesyłać szczegółowe zdarzenia debugujące widżetu do backendu (wysyłane są one na endpoint `/api/debug/turnstile`).
 
 Brak którejkolwiek z powyższych wartości uniemożliwi poprawne działanie weryfikacji CAPTCHA.
+
+### 📡 Logowanie do Elastic
+
+Backend potrafi buforować logi i wysyłać je do klastra ElasticSearch poprzez API bulk. Konfiguracja odbywa się przez zmienne środowiskowe:
+
+| Zmienna | Domyślna wartość | Opis |
+| --- | --- | --- |
+| `ELASTIC_URL` | `https://127.0.0.1:9200` | Adres klastra ElasticSearch. |
+| `ELASTIC_INDEX` | `website-backend` | Nazwa indeksu, do którego trafiają logi. |
+| `ELASTIC_API_KEY` | _(brak)_ | Wymagany klucz API (bez niego logowanie jest wyłączone). |
+| `ELASTIC_VERIFY_CERT` | `false` | Czy weryfikować certyfikat TLS (przy self-signed ustaw na `false`). |
+| `ELASTIC_CA_PATH` | _(brak)_ | Ścieżka do pliku CA, jeżeli `ELASTIC_VERIFY_CERT=true`. |
+| `ELASTIC_FLUSH_MS` | `60000` | Odstęp między cyklicznymi flushami bufora (w milisekundach). |
+| `ELASTIC_MAX_BUFFER` | `2000` | Maksymalna liczba wpisów w buforze przed wymuszeniem flush. |
+| `ELASTIC_MAX_BYTES` | `5242880` | Maksymalny rozmiar bufora (w bajtach). |
+| `ELASTIC_MAX_RETRIES` | `3` | Liczba ponowień wysyłki przy błędach 429/5xx. |
+
+Klucz API warto przechowywać w pliku `.env` (np. `ELASTIC_API_KEY=xxxx`) lub w menedżerze sekretów i przekazywać go do kontenera. Logger rejestruje zdarzenia lokalnie na stderr oraz wysyła je do Elastica – przy zakończeniu procesu bufor jest automatycznie flushowany.
 
 ### 💾 Przechowywanie danych backendu
 

--- a/backend/internal/logger/elastic/config.go
+++ b/backend/internal/logger/elastic/config.go
@@ -1,0 +1,149 @@
+package elastic
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config describes connection and buffering settings for the Elastic logger.
+type Config struct {
+	URL           string
+	Index         string
+	APIKey        string
+	VerifyCert    bool
+	CAPath        string
+	FlushInterval time.Duration
+	MaxBuffer     int
+	MaxBytes      int
+	MaxRetries    int
+}
+
+// FromEnv builds a configuration from environment variables. It returns the
+// parsed configuration, a boolean indicating whether logging should be enabled
+// and an error if any value is malformed.
+func FromEnv() (Config, bool, error) {
+	rawURL := strings.TrimSpace(os.Getenv("ELASTIC_URL"))
+	if rawURL == "" {
+		rawURL = "https://127.0.0.1:9200"
+	}
+
+	index := strings.TrimSpace(os.Getenv("ELASTIC_INDEX"))
+	if index == "" {
+		index = "website-backend"
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv("ELASTIC_API_KEY"))
+	if apiKey == "" {
+		return Config{}, false, nil
+	}
+
+	verifyCert, err := parseBoolEnv("ELASTIC_VERIFY_CERT", false)
+	if err != nil {
+		return Config{}, false, err
+	}
+
+	caPath := strings.TrimSpace(os.Getenv("ELASTIC_CA_PATH"))
+
+	flushMS, err := parseIntEnv("ELASTIC_FLUSH_MS", 60000)
+	if err != nil {
+		return Config{}, false, err
+	}
+	if flushMS <= 0 {
+		flushMS = 60000
+	}
+
+	maxBuffer, err := parseIntEnv("ELASTIC_MAX_BUFFER", 2000)
+	if err != nil {
+		return Config{}, false, err
+	}
+	if maxBuffer <= 0 {
+		maxBuffer = 2000
+	}
+
+	maxBytes, err := parseIntEnv("ELASTIC_MAX_BYTES", 5*1024*1024)
+	if err != nil {
+		return Config{}, false, err
+	}
+	if maxBytes <= 0 {
+		maxBytes = 5 * 1024 * 1024
+	}
+
+	maxRetries, err := parseIntEnv("ELASTIC_MAX_RETRIES", 3)
+	if err != nil {
+		return Config{}, false, err
+	}
+	if maxRetries < 0 {
+		maxRetries = 3
+	}
+
+	cfg := Config{
+		URL:           rawURL,
+		Index:         index,
+		APIKey:        apiKey,
+		VerifyCert:    verifyCert,
+		CAPath:        caPath,
+		FlushInterval: time.Duration(flushMS) * time.Millisecond,
+		MaxBuffer:     maxBuffer,
+		MaxBytes:      maxBytes,
+		MaxRetries:    maxRetries,
+	}
+
+	return cfg, true, nil
+}
+
+func parseBoolEnv(name string, def bool) (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def, nil
+	}
+	lower := strings.ToLower(raw)
+	switch lower {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	default:
+		return def, fmt.Errorf("%s: invalid boolean value %q", name, raw)
+	}
+}
+
+func parseIntEnv(name string, def int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return def, fmt.Errorf("%s: invalid integer value %q", name, raw)
+	}
+	return value, nil
+}
+
+// Validate ensures the configuration is internally consistent.
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.URL) == "" {
+		return fmt.Errorf("elastic url must not be empty")
+	}
+	if strings.TrimSpace(c.Index) == "" {
+		return fmt.Errorf("elastic index must not be empty")
+	}
+	if strings.TrimSpace(c.APIKey) == "" {
+		return fmt.Errorf("elastic api key must not be empty")
+	}
+	if c.FlushInterval <= 0 {
+		return fmt.Errorf("flush interval must be positive")
+	}
+	if c.MaxBuffer <= 0 {
+		return fmt.Errorf("max buffer must be positive")
+	}
+	if c.MaxBytes <= 0 {
+		return fmt.Errorf("max bytes must be positive")
+	}
+	if c.MaxRetries < 0 {
+		return fmt.Errorf("max retries must be zero or greater")
+	}
+	return nil
+}

--- a/backend/internal/logger/elastic/logger.go
+++ b/backend/internal/logger/elastic/logger.go
@@ -1,0 +1,344 @@
+package elastic
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Fields represent structured metadata attached to a log entry.
+type Fields map[string]any
+
+// Logger buffers log events and ships them to Elasticsearch using the bulk API.
+type Logger struct {
+	cfg     Config
+	baseURL *url.URL
+	client  *http.Client
+
+	mu         sync.Mutex
+	buffer     bytes.Buffer
+	entries    int
+	bufferSize int
+
+	flushMu sync.Mutex
+
+	ticker *time.Ticker
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+// NewLogger validates the configuration, creates an HTTP client and starts the
+// background flusher.
+func NewLogger(cfg Config) (*Logger, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	parsed, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parse elastic url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("elastic url must use http or https scheme")
+	}
+
+	transport := &http.Transport{}
+	if parsed.Scheme == "https" {
+		tlsConfig := &tls.Config{}
+		if !cfg.VerifyCert {
+			tlsConfig.InsecureSkipVerify = true //nolint:gosec // required for self-signed clusters
+		}
+		if cfg.CAPath != "" {
+			pemBytes, err := os.ReadFile(cfg.CAPath)
+			if err != nil {
+				return nil, fmt.Errorf("read elastic ca: %w", err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(pemBytes) {
+				return nil, errors.New("elastic ca: failed to append certificates")
+			}
+			tlsConfig.RootCAs = pool
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second, Transport: transport}
+
+	logger := &Logger{
+		cfg:     cfg,
+		baseURL: parsed,
+		client:  client,
+		ticker:  time.NewTicker(cfg.FlushInterval),
+		stopCh:  make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+
+	go logger.run()
+
+	return logger, nil
+}
+
+func (l *Logger) run() {
+	defer close(l.doneCh)
+	for {
+		select {
+		case <-l.ticker.C:
+			_ = l.Flush(context.Background())
+		case <-l.stopCh:
+			return
+		}
+	}
+}
+
+// Write implements io.Writer so the logger can be used as log output sink.
+func (l *Logger) Write(p []byte) (int, error) {
+	message := strings.TrimSpace(string(p))
+	if message == "" {
+		return len(p), nil
+	}
+	l.Log("info", message, nil)
+	return len(p), nil
+}
+
+// Log enqueues a structured log entry for asynchronous delivery.
+func (l *Logger) Log(level string, message string, fields Fields) {
+	entry := make(map[string]any, len(fields)+4)
+	entry["@timestamp"] = time.Now().UTC().Format(time.RFC3339Nano)
+	entry["level"] = strings.ToUpper(strings.TrimSpace(level))
+	entry["message"] = message
+	entry["service"] = "KupPixelBackend"
+	for k, v := range fields {
+		if k == "" || v == nil {
+			continue
+		}
+		entry[k] = v
+	}
+
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ElasticLogger] marshal entry failed: %v\n", err)
+		return
+	}
+
+	meta := []byte("{\"index\":{}}\n")
+	ndjson := append(meta, payload...)
+	ndjson = append(ndjson, '\n')
+
+	l.enqueue(ndjson)
+}
+
+func (l *Logger) enqueue(item []byte) {
+	l.mu.Lock()
+	l.buffer.Write(item)
+	l.entries++
+	l.bufferSize += len(item)
+	shouldFlush := l.entries >= l.cfg.MaxBuffer || l.bufferSize >= l.cfg.MaxBytes
+	l.mu.Unlock()
+
+	if shouldFlush {
+		go func() {
+			_ = l.Flush(context.Background())
+		}()
+	}
+}
+
+// Flush immediately sends the buffered entries to Elasticsearch.
+func (l *Logger) Flush(ctx context.Context) error {
+	l.flushMu.Lock()
+	defer l.flushMu.Unlock()
+
+	l.mu.Lock()
+	if l.entries == 0 {
+		l.mu.Unlock()
+		return nil
+	}
+
+	batch := make([]byte, l.buffer.Len())
+	copy(batch, l.buffer.Bytes())
+	l.buffer.Reset()
+	l.entries = 0
+	l.bufferSize = 0
+	l.mu.Unlock()
+
+	if err := l.sendWithRetry(ctx, batch); err != nil {
+		l.requeue(batch)
+		return err
+	}
+	return nil
+}
+
+func (l *Logger) requeue(batch []byte) {
+	lines := bytes.Split(batch, []byte{'\n'})
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := 0; i+1 < len(lines); i += 2 {
+		meta := lines[i]
+		if len(bytes.TrimSpace(meta)) == 0 {
+			continue
+		}
+		doc := lines[i+1]
+		nd := append(append(append([]byte{}, meta...), '\n'), append(doc, '\n')...)
+		l.buffer.Write(nd)
+		l.entries++
+		l.bufferSize += len(nd)
+		if l.entries >= l.cfg.MaxBuffer*2 || l.bufferSize >= l.cfg.MaxBytes*2 {
+			break
+		}
+	}
+}
+
+func (l *Logger) sendWithRetry(ctx context.Context, payload []byte) error {
+	var lastErr error
+	for attempt := 0; attempt <= l.cfg.MaxRetries; attempt++ {
+		status, body, err := l.post(ctx, payload)
+		if err != nil {
+			lastErr = err
+		} else if status >= 200 && status < 300 {
+			l.reportPartialErrors(body)
+			return nil
+		} else {
+			truncated := truncateBody(body)
+			lastErr = fmt.Errorf("bulk request failed: status=%d body=%s", status, truncated)
+			if status != http.StatusTooManyRequests && (status < 500 || status >= 600) {
+				return lastErr
+			}
+		}
+
+		if attempt < l.cfg.MaxRetries {
+			backoff := time.Duration(min(15000, 500*(1<<attempt))) * time.Millisecond
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return lastErr
+}
+
+func (l *Logger) post(ctx context.Context, payload []byte) (int, []byte, error) {
+	endpoint := *l.baseURL
+	cleanPath := strings.TrimRight(endpoint.Path, "/")
+	escapedIndex := url.PathEscape(l.cfg.Index)
+	endpoint.Path = path.Join(cleanPath, escapedIndex, "_bulk")
+	if !strings.HasPrefix(endpoint.Path, "/") {
+		endpoint.Path = "/" + endpoint.Path
+	}
+	endpoint.RawQuery = ""
+	endpoint.Fragment = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(payload))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	req.Header.Set("Authorization", "ApiKey "+l.cfg.APIKey)
+
+	resp, err := l.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, body, nil
+}
+
+func (l *Logger) reportPartialErrors(body []byte) {
+	if len(body) == 0 {
+		return
+	}
+	var parsed bulkResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return
+	}
+	if !parsed.Errors {
+		return
+	}
+	first := parsed.FirstError()
+	if first == nil {
+		return
+	}
+	data, err := json.Marshal(first)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[ElasticLogger] partial error: %s\n", string(data))
+}
+
+// Close stops the background flusher and drains the buffer.
+func (l *Logger) Close(ctx context.Context) error {
+	l.ticker.Stop()
+	close(l.stopCh)
+	<-l.doneCh
+	return l.Flush(ctx)
+}
+
+func truncateBody(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	const limit = 512
+	if len(body) <= limit {
+		return string(body)
+	}
+	return string(body[:limit]) + "…"
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+type bulkResponse struct {
+	Errors bool                          `json:"errors"`
+	Items  []map[string]bulkResponseItem `json:"items"`
+}
+
+type bulkResponseItem struct {
+	Status int            `json:"status"`
+	Error  map[string]any `json:"error"`
+}
+
+func (r *bulkResponse) FirstError() map[string]any {
+	if r == nil {
+		return nil
+	}
+	for _, item := range r.Items {
+		keys := make([]string, 0, len(item))
+		for key := range item {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			entry := item[key]
+			if entry.Error != nil {
+				entryMap := map[string]any{
+					"operation": key,
+					"status":    entry.Status,
+					"error":     entry.Error,
+				}
+				return entryMap
+			}
+		}
+	}
+	return nil
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,16 @@ services:
       # - "3000:3000"
     environment:
       - NODE_ENV=production
+      - ELASTIC_URL=${ELASTIC_URL:-https://127.0.0.1:9200}
+      - ELASTIC_INDEX=${ELASTIC_INDEX:-website-backend}
+      - ELASTIC_API_KEY=${ELASTIC_API_KEY}
+      - ELASTIC_VERIFY_CERT=${ELASTIC_VERIFY_CERT:-false}
+      - ELASTIC_CA_PATH=${ELASTIC_CA_PATH:-}
+      - ELASTIC_FLUSH_MS=${ELASTIC_FLUSH_MS:-60000}
+      - ELASTIC_MAX_BUFFER=${ELASTIC_MAX_BUFFER:-2000}
+      - ELASTIC_MAX_BYTES=${ELASTIC_MAX_BYTES:-5242880}
+      - ELASTIC_MAX_RETRIES=${ELASTIC_MAX_RETRIES:-3}
+      - VITE_TURNSTILE_DEBUG=${VITE_TURNSTILE_DEBUG:-false}
     network_mode: host
     volumes:
       - pixel-data:/app/data

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,6 @@
 # Public Cloudflare Turnstile site key used by the frontend bundle.
 # Replace the placeholder with the site key from your Cloudflare dashboard.
 VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+
+# Set to "true" to send verbose Turnstile lifecycle events to the backend debug endpoint.
+VITE_TURNSTILE_DEBUG=false

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -2,4 +2,5 @@
 
 interface ImportMetaEnv {
   readonly VITE_TURNSTILE_SITE_KEY: string;
+  readonly VITE_TURNSTILE_DEBUG?: string;
 }

--- a/frontend/src/utils/turnstile.ts
+++ b/frontend/src/utils/turnstile.ts
@@ -1,69 +1,164 @@
 export type TurnstileWidgetId = string;
 
 export type TurnstileRenderOptions = {
-sitekey: string;
-callback?: (token: string) => void;
-"expired-callback"?: () => void;
-"error-callback"?: () => void;
-action?: string;
-theme?: "light" | "dark" | "auto";
+  sitekey: string;
+  callback?: (token: string) => void;
+  "expired-callback"?: () => void;
+  "error-callback"?: () => void;
+  action?: string;
+  theme?: "light" | "dark" | "auto";
 };
 
 export interface TurnstileInstance {
-render: (container: HTMLElement, options: TurnstileRenderOptions) => TurnstileWidgetId;
-reset: (widgetId?: TurnstileWidgetId) => void;
-remove: (widgetId?: TurnstileWidgetId) => void;
+  render: (container: HTMLElement, options: TurnstileRenderOptions) => TurnstileWidgetId;
+  reset: (widgetId?: TurnstileWidgetId) => void;
+  remove: (widgetId?: TurnstileWidgetId) => void;
 }
 
+export type TurnstileDebugOptions = {
+  status?: string;
+  detail?: unknown;
+  error?: string;
+  meta?: Record<string, unknown>;
+};
+
 declare global {
-interface Window {
-turnstile?: TurnstileInstance;
-}
+  interface Window {
+    turnstile?: TurnstileInstance;
+  }
 }
 
 const SCRIPT_ID = "cloudflare-turnstile";
 const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+const DEBUG_ENDPOINT = "/api/debug/turnstile";
+const TURNSTILE_DEBUG_ENABLED = import.meta.env.VITE_TURNSTILE_DEBUG === "true";
+
+function normalizeDetail(detail: unknown): unknown {
+  if (detail === undefined) {
+    return undefined;
+  }
+  if (detail === null) {
+    return null;
+  }
+  if (detail instanceof Error) {
+    return {
+      name: detail.name,
+      message: detail.message,
+      stack: detail.stack,
+    };
+  }
+  if (typeof detail === "string" || typeof detail === "number" || typeof detail === "boolean") {
+    return detail;
+  }
+  try {
+    return JSON.parse(JSON.stringify(detail));
+  } catch (error) {
+    return String(detail);
+  }
+}
+
+async function postTurnstileDebug(payload: Record<string, unknown>): Promise<void> {
+  if (typeof fetch !== "function") {
+    return;
+  }
+  try {
+    await fetch(DEBUG_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("Failed to report Turnstile debug", error);
+    }
+  }
+}
+
+export function reportTurnstileDebug(stage: string, options: TurnstileDebugOptions = {}): void {
+  if (!TURNSTILE_DEBUG_ENABLED || typeof window === "undefined") {
+    return;
+  }
+  const payload: Record<string, unknown> = { stage };
+  if (options.status) {
+    payload.status = options.status;
+  }
+  const normalizedDetail = normalizeDetail(options.detail);
+  if (normalizedDetail !== undefined) {
+    payload.detail = normalizedDetail;
+  }
+  if (options.error) {
+    payload.error = options.error;
+  }
+  if (options.meta && Object.keys(options.meta).length > 0) {
+    payload.meta = options.meta;
+  }
+  void postTurnstileDebug(payload);
+}
 
 let loaderPromise: Promise<void> | null = null;
 
 export function loadTurnstile(): Promise<void> {
-if (typeof window === "undefined") {
-return Promise.reject(new Error("Turnstile is not available in this environment"));
-}
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("Turnstile is not available in this environment"));
+  }
 
-if (window.turnstile) {
-return Promise.resolve();
-}
+  if (window.turnstile) {
+    reportTurnstileDebug("loader:existing-instance", { status: "ready" });
+    return Promise.resolve();
+  }
 
-if (loaderPromise) {
-return loaderPromise;
-}
+  if (loaderPromise) {
+    reportTurnstileDebug("loader:pending", { status: "pending" });
+    return loaderPromise;
+  }
 
-loaderPromise = new Promise((resolve, reject) => {
-const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
-if (existing) {
-if (window.turnstile) {
-resolve();
-return;
-}
-existing.addEventListener("load", () => resolve(), { once: true });
-existing.addEventListener(
-"error",
-() => reject(new Error("Failed to load Cloudflare Turnstile")),
-{ once: true }
-);
-return;
-}
+  reportTurnstileDebug("loader:start", { status: "pending" });
+  loaderPromise = new Promise((resolve, reject) => {
+    const existing = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    if (existing) {
+      reportTurnstileDebug("loader:reuse-script", { status: "pending" });
+      if (window.turnstile) {
+        reportTurnstileDebug("loader:reuse-script-ready", { status: "ready" });
+        resolve();
+        return;
+      }
+      existing.addEventListener(
+        "load",
+        () => {
+          reportTurnstileDebug("loader:script-loaded", { status: "success" });
+          resolve();
+        },
+        { once: true }
+      );
+      existing.addEventListener(
+        "error",
+        () => {
+          reportTurnstileDebug("loader:script-error", { status: "error", error: "script load error" });
+          reject(new Error("Failed to load Cloudflare Turnstile"));
+        },
+        { once: true }
+      );
+      return;
+    }
 
-const script = document.createElement("script");
-script.id = SCRIPT_ID;
-script.src = SCRIPT_SRC;
-script.async = true;
-script.defer = true;
-script.onload = () => resolve();
-script.onerror = () => reject(new Error("Failed to load Cloudflare Turnstile"));
-document.head.appendChild(script);
-});
+    reportTurnstileDebug("loader:inject", { status: "pending" });
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      reportTurnstileDebug("loader:script-loaded", { status: "success" });
+      resolve();
+    };
+    script.onerror = () => {
+      reportTurnstileDebug("loader:script-error", { status: "error", error: "script load error" });
+      reject(new Error("Failed to load Cloudflare Turnstile"));
+    };
+    document.head.appendChild(script);
+  });
 
-return loaderPromise;
+  return loaderPromise;
 }


### PR DESCRIPTION
## Summary
- add a buffered ElasticSearch logger package and wire it into the backend startup flow
- instrument Cloudflare Turnstile verification and expose a frontend debug reporting endpoint
- send frontend Turnstile lifecycle events when VITE_TURNSTILE_DEBUG=true and document the new configuration knobs

## Testing
- go test ./...
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b1cc77e883268def2589c527fddd