### PR TITLE
Add pixel URL blacklist enforcement

### DIFF
--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -1,6 +1,19 @@
 {
   // Number of points required to claim a pixel.
   "pixelCostPoints": 10,
+  // List of domains and keywords that are blocked from being used in pixel URLs.
+  "pixelUrlBlacklist": [
+    "porn",
+    "pornhub.com",
+    "xvideos.com",
+    "xnxx.com",
+    "redtube.com",
+    "onlyfans.com",
+    "sex",
+    "xxx",
+    "nsfw",
+    "fuck"
+  ],
   // Set to true to automatically mark newly created accounts as verified and skip emails.
   "disableVerificationEmail": false,
   // Secret key used to verify Cloudflare Turnstile challenges on protected forms.


### PR DESCRIPTION
## Summary
- add a configurable pixel URL blacklist with sensible defaults and JSON normalisation
- document the new blacklist option in the example config file
- enforce the blacklist when updating pixels and add regression tests for blocked and allowed URLs

## Testing
- (cd backend && go test ./...)


------
https://chatgpt.com/codex/tasks/task_e_68d5d34bcc948326b2df347f2e7129e1