### PR TITLE
Disable touch scrolling on pixel canvas

### DIFF
--- a/frontend/src/components/PixelCanvas.tsx
+++ b/frontend/src/components/PixelCanvas.tsx
@@ -557,7 +557,9 @@ export default function PixelCanvas({
         style={{
           imageRendering: "pixelated",
           aspectRatio: `${width} / ${height}`,
-          backgroundColor: "#111827"
+          backgroundColor: "#111827",
+          touchAction: "none",
+          overscrollBehavior: "contain",
         }}
       />
       {selectionRect && (


### PR DESCRIPTION
## Summary
- prevent the browser from handling touch scroll/zoom gestures on the pixel canvas
- set touchAction: none and overscrollBehavior: contain on the canvas element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5dcd040808326b2273193b2b4d13d